### PR TITLE
feat(common): refine globs for test files

### DIFF
--- a/react.json
+++ b/react.json
@@ -75,7 +75,16 @@
         "react/style-prop-object": "error",
         "react-hooks/exhaustive-deps": "error",
         "react-hooks/rules-of-hooks": "error",
-        "import/dynamic-import-chunkname": "error"
+        "import/dynamic-import-chunkname": "error",
+        "import/no-extraneous-dependencies": [
+            "error",
+            {
+                "devDependencies": [
+                    "**/tests/**",
+                    "**/*spec.*"
+                ]
+            }
+        ]
     },
     "settings": {
         "react": {


### PR DESCRIPTION
## What?
Reconfigured globs for eslint rule `import/no-extraneous-dependencies`.

## Why?
We found when renaming test files to just `spec.ts` eslint would 😢since the default glob was `**/*.spec.*`.

## Testing / Proof
* Manual - inserted same rule into local repository. 

@bigcommerce/frontend
