### PR TITLE
fix(common): add missing plugin import

### DIFF
--- a/react.json
+++ b/react.json
@@ -6,6 +6,7 @@
         "browser": true
     },
     "plugins": [
+        "import",
         "react",
         "react-hooks"
     ],


### PR DESCRIPTION
## What
Add missing plugin `import`.

## Why
When extending `eslint-config` I get an error that eslint can't find the rule `import/dynamic-import-chunkname`.

@bigcommerce/frontend 