### PR TITLE
feat(plugin): adds jsx-short-circuit-conditionals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .log
-/node_modules
+node_modules

--- a/commit-validation.json
+++ b/commit-validation.json
@@ -1,6 +1,7 @@
 {
     "scopes": [
         "common",
-        "core"
+        "core",
+        "plugin"
     ]
 }

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -12,6 +12,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:import/typescript',
+    'plugin:@bigcommerce/recommended',
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/file.tsx
+++ b/file.tsx
@@ -1,0 +1,1 @@
+// This file is used by our tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -464,6 +464,73 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@bigcommerce/eslint-plugin": {
+      "version": "file:plugin",
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^4.24.0",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "4.24.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.24.0.tgz",
+          "integrity": "sha512-IwTT2VNDKH1h8RZseMH4CcYBz6lTvRoOLDuuqNZZoThvfHEhOiZPQCow+5El3PtyxJ1iDr6UXZwYtE3yZQjhcw==",
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/scope-manager": "4.24.0",
+            "@typescript-eslint/types": "4.24.0",
+            "@typescript-eslint/typescript-estree": "4.24.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "4.24.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz",
+          "integrity": "sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==",
+          "requires": {
+            "@typescript-eslint/types": "4.24.0",
+            "@typescript-eslint/visitor-keys": "4.24.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.24.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.24.0.tgz",
+          "integrity": "sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q=="
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.24.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.24.0.tgz",
+          "integrity": "sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==",
+          "requires": {
+            "@typescript-eslint/types": "4.24.0",
+            "@typescript-eslint/visitor-keys": "4.24.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.24.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.24.0.tgz",
+          "integrity": "sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==",
+          "requires": {
+            "@typescript-eslint/types": "4.24.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "@bigcommerce/validate-commits": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@bigcommerce/validate-commits/-/validate-commits-2.2.0.tgz",
@@ -2590,6 +2657,12 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2815,6 +2888,17 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "endent": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/endent/-/endent-2.0.1.tgz",
+      "integrity": "sha512-mADztvcC+vCk4XEZaCz6xIPO2NHQuprv5CAEjuVAu6aZwqAj7nVNlMyl1goPFYqCCpS2OJV9jwpumJLkotZrNw==",
+      "dev": true,
+      "requires": {
+        "dedent": "^0.7.0",
+        "fast-json-parse": "^1.0.3",
+        "objectorarray": "^1.0.4"
       }
     },
     "enquirer": {
@@ -3720,6 +3804,12 @@
         "micromatch": "^4.0.2",
         "picomatch": "^2.2.1"
       }
+    },
+    "fast-json-parse": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
+      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -7396,6 +7486,12 @@
         "es-abstract": "^1.18.0-next.2",
         "has": "^1.0.3"
       }
+    },
+    "objectorarray": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.4.tgz",
+      "integrity": "sha512-91k8bjcldstRz1bG6zJo8lWD7c6QXcB4nTDUqiEvIL1xAsLoZlOOZZG+nd6YPz+V7zY1580J4Xxh1vZtyv4i/w==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "index.js",
     "configs",
     "patch",
+    "plugin",
     "utils",
     "prettier",
     "prettier.config.js"
@@ -23,6 +24,7 @@
     "validate-commits": "validate-commits"
   },
   "dependencies": {
+    "@bigcommerce/eslint-plugin": "file:plugin",
     "@rushstack/eslint-patch": "^1.0.6",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
@@ -42,6 +44,7 @@
   },
   "devDependencies": {
     "@bigcommerce/validate-commits": "^2.0.2",
+    "endent": "^2.0.1",
     "eslint": "^7.25.0",
     "jest": "^26.6.3",
     "react": "^17.0.2",

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,0 +1,17 @@
+const jsxShortCircuitConditionals = require('./rules/jsx-short-circuit-conditionals');
+
+module.exports = {
+  configs: {
+    recommended: {
+      parser: '@typescript-eslint/parser',
+      parserOptions: { sourceType: 'module' },
+      plugins: ['@bigcommerce'],
+      rules: {
+        '@bigcommerce/jsx-short-circuit-conditionals': 'error',
+      },
+    },
+  },
+  rules: {
+    'jsx-short-circuit-conditionals': jsxShortCircuitConditionals,
+  },
+};

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@bigcommerce/eslint-plugin",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "@typescript-eslint/experimental-utils": "^4.24.0",
+    "tsutils": "^3.21.0"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/parser": "^4.0.0",
+    "eslint": "^7.0.0",
+    "typescript": "^4.0.0"
+  },
+  "devDependencies": {
+    "endent": "^2.0.1"
+  }
+}

--- a/plugin/rules/jsx-short-circuit-conditionals.js
+++ b/plugin/rules/jsx-short-circuit-conditionals.js
@@ -1,0 +1,84 @@
+/* eslint-disable sort-keys */
+const { ESLintUtils } = require('@typescript-eslint/experimental-utils');
+const tsutils = require('tsutils');
+const ts = require('typescript');
+
+module.exports = {
+  name: 'jsx-short-circuit-conditionals',
+  meta: {
+    type: 'problem',
+    fixable: true,
+  },
+  docs: {
+    description: 'Disallows usage of string / number while short-circuiting jsx',
+    suggestion: true,
+    recommended: true,
+  },
+  create(context) {
+    const parserServices = ESLintUtils.getParserServices(context);
+    const typeChecker = parserServices.program.getTypeChecker();
+
+    function checkNode(node) {
+      const targetNode = node.left;
+      const tsNode = parserServices.esTreeNodeToTSNodeMap.get(targetNode);
+      const type = typeChecker.getTypeAtLocation(tsNode);
+      const types = tsutils.unionTypeParts(type);
+
+      const suggestions = [
+        {
+          desc: `Make it a boolean by casting it: Boolean(${targetNode.name})`,
+          fix: (fixer) => {
+            return [
+              fixer.insertTextBefore(targetNode, `Boolean(`),
+              fixer.insertTextAfter(targetNode, ')'),
+            ];
+          },
+        },
+      ];
+
+      if (isString(types)) {
+        if (types.length === 1) {
+          suggestions.unshift({
+            desc: `Make it a boolean by checking empty string: ${targetNode.name} !== ''`,
+            fix: (fixer) => fixer.insertTextAfter(targetNode, " !== ''"),
+          });
+        }
+
+        return context.report({
+          node,
+          message: 'Short-circuiting jsx with a string is not allowed.',
+          suggest: suggestions,
+        });
+      }
+
+      if (isNumber(types)) {
+        if (types.length === 1) {
+          suggestions.unshift({
+            desc: `Make it a boolean by checking: ${targetNode.name} > 0`,
+            fix: (fixer) => fixer.insertTextAfter(targetNode, ' > 0'),
+          });
+        }
+
+        return context.report({
+          node,
+          message: 'Short-circuiting jsx with a number is not allowed.',
+          suggest: suggestions,
+        });
+      }
+
+      return null;
+    }
+
+    function isString(types) {
+      return types.some((type) => tsutils.isTypeFlagSet(type, ts.TypeFlags.StringLike));
+    }
+
+    function isNumber(types) {
+      return types.some((type) => tsutils.isTypeFlagSet(type, ts.TypeFlags.NumberLike));
+    }
+
+    return {
+      ":matches(JSXElement, JSXFragment) > JSXExpressionContainer > LogicalExpression[operator='&&']": checkNode,
+    };
+  },
+};

--- a/plugin/tests/jsx-short-circuit-conditionals.spec.js
+++ b/plugin/tests/jsx-short-circuit-conditionals.spec.js
@@ -1,0 +1,185 @@
+/* eslint-disable sort-keys */
+const { ESLintUtils } = require('@typescript-eslint/experimental-utils');
+const endent = require('endent').default;
+
+const rule = require('../rules/jsx-short-circuit-conditionals');
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    tsconfigRootDir: process.cwd(),
+    project: './tsconfig.json',
+    ecmaFeatures: { jsx: true },
+  },
+});
+
+ruleTester.run('jsx-short-circuit-conditionals', rule, {
+  valid: [
+    {
+      code: endent`
+        const Test = () => (
+          <div>
+            {true && <span>test</span>}
+          </div>
+        );`,
+    },
+    {
+      code: endent`
+        const Test = () => (
+          <div>
+            {false && <span>test</span>}
+          </div>
+        );`,
+    },
+    {
+      code: endent`
+        const Test = () => (
+          <div>
+            {'string ternary' ? <span>test</span> : null}
+          </div>
+        );`,
+    },
+    {
+      code: endent`
+        const Test = () => (
+          <div>
+            {[] && <span>test</span>}
+          </div>
+        );`,
+    },
+    {
+      code: endent`
+        const Test = () => (
+          <div>
+            {{} && <span>test</span>}
+          </div>
+        );`,
+    },
+  ],
+  invalid: [
+    {
+      code: endent`
+        const name: string = 'Test Name';
+        const Test = () => (
+          <div>
+            {name && <span>{name}</span>}
+          </div>
+        );`,
+      errors: [
+        {
+          message: /Short-circuiting jsx with a string is not allowed./i,
+          suggestions: [
+            {
+              desc: "Make it a boolean by checking empty string: name !== ''",
+              output: endent`
+                const name: string = 'Test Name';
+                const Test = () => (
+                  <div>
+                    {name !== '' && <span>{name}</span>}
+                  </div>
+                );`,
+            },
+            {
+              desc: 'Make it a boolean by casting it: Boolean(name)',
+              output: endent`
+                const name: string = 'Test Name';
+                const Test = () => (
+                  <div>
+                    {Boolean(name) && <span>{name}</span>}
+                  </div>
+                );`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: endent`
+          const name: string | undefined;
+          const Test = () => (
+            <div>
+              {name && <span>{name}</span>}
+            </div>
+          );`,
+      errors: [
+        {
+          message: /Short-circuiting jsx with a string is not allowed./i,
+          suggestions: [
+            {
+              desc: 'Make it a boolean by casting it: Boolean(name)',
+              output: endent`
+                  const name: string | undefined;
+                  const Test = () => (
+                    <div>
+                      {Boolean(name) && <span>{name}</span>}
+                    </div>
+                  );`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: endent`
+          const count: number = 0;
+          const Test = () => (
+            <div>
+              {count && <span>{count}</span>}
+            </div>
+          );`,
+      errors: [
+        {
+          message: /Short-circuiting jsx with a number is not allowed./i,
+          suggestions: [
+            {
+              desc: 'Make it a boolean by checking: count > 0',
+              output: endent`
+                  const count: number = 0;
+                  const Test = () => (
+                    <div>
+                      {count > 0 && <span>{count}</span>}
+                    </div>
+                  );`,
+            },
+            {
+              desc: 'Make it a boolean by casting it: Boolean(count)',
+              output: endent`
+                  const count: number = 0;
+                  const Test = () => (
+                    <div>
+                      {Boolean(count) && <span>{count}</span>}
+                    </div>
+                  );`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: endent`
+          const count: number | undefined;
+          const Test = () => (
+            <div>
+              {count && <span>{count}</span>}
+            </div>
+          );`,
+      errors: [
+        {
+          message: /Short-circuiting jsx with a number is not allowed./i,
+          suggestions: [
+            {
+              desc: 'Make it a boolean by casting it: Boolean(count)',
+              output: endent`
+                  const count: number | undefined;
+                  const Test = () => (
+                    <div>
+                      {Boolean(count) && <span>{count}</span>}
+                    </div>
+                  );`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});

--- a/test/__snapshots__/eslint.spec.js.snap
+++ b/test/__snapshots__/eslint.spec.js.snap
@@ -5464,6 +5464,7 @@ Object {
     "react",
     "jsx-a11y",
     "react-hooks",
+    "@bigcommerce",
     "@typescript-eslint",
   ],
   "reportUnusedDisableDirectives": true,
@@ -5473,6 +5474,9 @@ Object {
     ],
     "@babel/semi": Array [
       "off",
+    ],
+    "@bigcommerce/jsx-short-circuit-conditionals": Array [
+      "error",
     ],
     "@typescript-eslint/adjacent-overload-signatures": Array [
       "error",
@@ -7564,6 +7568,7 @@ Object {
     "react",
     "jsx-a11y",
     "react-hooks",
+    "@bigcommerce",
     "@typescript-eslint",
   ],
   "reportUnusedDisableDirectives": true,
@@ -7573,6 +7578,9 @@ Object {
     ],
     "@babel/semi": Array [
       "off",
+    ],
+    "@bigcommerce/jsx-short-circuit-conditionals": Array [
+      "error",
     ],
     "@typescript-eslint/adjacent-overload-signatures": Array [
       "error",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "target": "es2017",
+    "lib": ["es2017"],
+  },
+  "include": ["**/*"]
+}


### PR DESCRIPTION
Introduces an eslint plugin: `@bigcommerce/eslint-plugin`

Currently it has a single rule `jsx-short-circuit-conditionals`. This rule is for TS files only as it requires typing info.

**jsx-short-circuit-conditionals**
Disallows usage of string / number while short-circuiting jsx.

Reasoning: This rule aims to avoid bugs when doing things like `{items.length && <div>...}`, if `items.length === 0` react will render a `0`. Same goes for an empty string, which can cause unexpected layout shifts.

Examples of **incorrect** code for this rule:
```jsx
// Assuming name is string (or string | any other type)
{name && <span>{name}</span>}
{name.length && <span>{name}</span>}
```

Examples of **correct** code for this rule:
```jsx
{name !== '' && <span>{name}</span>}
{name.length > 0 && <span>{name}</span>}
{name ? <span>{name}</span> : null}
```

The rule also comes with suggestions with auto-fixes:

*Note: Disregard the plugin name, it is `@bigcommerce` and not `deini`*

![image](https://user-images.githubusercontent.com/2752665/119067640-29b05b80-b9a8-11eb-8403-be471f658574.png)

![image](https://user-images.githubusercontent.com/2752665/119067684-3765e100-b9a8-11eb-890c-f749cec4d6a6.png)

More examples on the tests.
