### PR TITLE
chore(common): prepare for prerelease

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
     "version": {
       "allowBranch": "master",
       "conventionalCommits": true,
-      "message": "chore(release): publish"
+      "message": "chore(release): publish %s"
     }
   },
   "ignoreChanges": ["**/*spec.js", "**/*.snap", "**/*.md"]

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -20,7 +20,7 @@
     "directory": "packages/eslint-config"
   },
   "dependencies": {
-    "@bigcommerce/eslint-plugin": "^1.0.0",
+    "@bigcommerce/eslint-plugin": "^0.1.0",
     "@rushstack/eslint-patch": "^1.0.6",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/eslint-plugin",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "main": "index.js",
   "author": "BigCommerce",
   "license": "MIT",


### PR DESCRIPTION
- Add version number to release commit
- Make `eslint-plugin` first version `0.1.0` so when we do a `premajor` we get `1.0.0-alpha.0` and not `2.0.0...`