### PR TITLE
chore(common): re-generate changelogs

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
     "version": {
       "allowBranch": "master",
       "conventionalCommits": true,
-      "message": "chore(release): publish %s"
+      "message": "chore(release): publish"
     }
   },
   "ignoreChanges": ["**/*spec.js", "**/*.snap", "**/*.md"]

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -5,21 +5,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # 2.0.0-alpha.0 (2021-05-27)
 
+### Features
+
+* **core:** modern resolution patch + prettier ([ca54583](https://github.com/bigcommerce/eslint-config/commit/ca5458390d5cac4eaf731669e1e0690861455851))
+* **core:** add missing ts rules ([e750786](https://github.com/bigcommerce/eslint-config/commit/e750786c2754a2d12b06dfc36df9379997e77823))
+* **core:** add import and strict boolean rules ([c1e23af](https://github.com/bigcommerce/eslint-config/commit/c1e23af30ffad0b53bbfb399e1120f3423f9a8c5))
+* **core:** tweak conflicting rules ([369c42a](https://github.com/bigcommerce/eslint-config/commit/369c42ab85e563d813ae71b0d24cbd0cb85438a2))
 
 ### Bug Fixes
 
 * **config:** no longer turn off all ts eslint rules ([7efcafd](https://github.com/bigcommerce/eslint-config/commit/7efcafd7cfa23087612a89b4f5ffd99bc4017e50))
 
-
-
-
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
-
 <a name="1.0.1"></a>
-## [1.0.1](https://github.com/bigcommerce/eslint-config/compare/v1.0.0...v1.0.1) (2020-03-10)
+# [1.0.1](https://github.com/bigcommerce/eslint-config/compare/v1.0.0...v1.0.1) (2020-03-10)
 
 
 ### Bug Fixes

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -5,4 +5,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # 1.0.0-alpha.0 (2021-05-27)
 
-**Note:** Version bump only for package @bigcommerce/eslint-plugin
+### Features
+
+* **plugin:** adds jsx-short-circuit-conditionals ([af22c10](https://github.com/bigcommerce/eslint-config/commit/af22c10b7a13dcd6346cb4d4135d3105e97e7c18))


### PR DESCRIPTION
Since the changelogs were done pre-monorepo, they got messed up on first release. Re-generated them and we should be good moving forward.