### PR TITLE
feat(config): enable anchor-is-valid and remove jsx-ident-props

### DIFF
--- a/packages/eslint-config/configs/react.js
+++ b/packages/eslint-config/configs/react.js
@@ -11,8 +11,6 @@ module.exports = {
   },
   plugins: ['react-hooks'],
   rules: {
-    // This rule is not compatible with Next.js's <Link /> components
-    'jsx-a11y/anchor-is-valid': 'off',
     'react-hooks/exhaustive-deps': 'error',
     'react-hooks/rules-of-hooks': 'error',
     'react/destructuring-assignment': 'error',
@@ -28,7 +26,6 @@ module.exports = {
     ],
     'react/jsx-first-prop-new-line': ['error', 'multiline-multiprop'],
     'react/jsx-fragments': ['error', 'syntax'],
-    'react/jsx-indent-props': ['error', 4],
     'react/jsx-no-bind': 'error',
     'react/jsx-no-useless-fragment': 'error',
     'react/jsx-one-expression-per-line': [

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -491,7 +491,7 @@ Object {
       "error",
     ],
     "jsx-a11y/anchor-is-valid": Array [
-      "off",
+      "error",
     ],
     "jsx-a11y/aria-activedescendant-has-tabindex": Array [
       "error",
@@ -1483,8 +1483,7 @@ Object {
       "off",
     ],
     "react/jsx-indent-props": Array [
-      "error",
-      4,
+      "off",
     ],
     "react/jsx-key": Array [
       2,
@@ -2269,7 +2268,7 @@ Object {
       "error",
     ],
     "jsx-a11y/anchor-is-valid": Array [
-      "off",
+      "error",
     ],
     "jsx-a11y/aria-activedescendant-has-tabindex": Array [
       "error",
@@ -3261,8 +3260,7 @@ Object {
       "off",
     ],
     "react/jsx-indent-props": Array [
-      "error",
-      4,
+      "off",
     ],
     "react/jsx-key": Array [
       2,
@@ -4046,7 +4044,7 @@ Object {
       "error",
     ],
     "jsx-a11y/anchor-is-valid": Array [
-      "off",
+      "error",
     ],
     "jsx-a11y/aria-activedescendant-has-tabindex": Array [
       "error",
@@ -5038,8 +5036,7 @@ Object {
       "off",
     ],
     "react/jsx-indent-props": Array [
-      "error",
-      4,
+      "off",
     ],
     "react/jsx-key": Array [
       2,
@@ -6088,7 +6085,7 @@ Object {
       "error",
     ],
     "jsx-a11y/anchor-is-valid": Array [
-      "off",
+      "error",
     ],
     "jsx-a11y/aria-activedescendant-has-tabindex": Array [
       "error",
@@ -7094,8 +7091,7 @@ Object {
       "off",
     ],
     "react/jsx-indent-props": Array [
-      "error",
-      4,
+      "off",
     ],
     "react/jsx-key": Array [
       2,
@@ -8182,7 +8178,7 @@ Object {
       "error",
     ],
     "jsx-a11y/anchor-is-valid": Array [
-      "off",
+      "error",
     ],
     "jsx-a11y/aria-activedescendant-has-tabindex": Array [
       "error",
@@ -9188,8 +9184,7 @@ Object {
       "off",
     ],
     "react/jsx-indent-props": Array [
-      "error",
-      4,
+      "off",
     ],
     "react/jsx-key": Array [
       2,


### PR DESCRIPTION
Update rules

`jsx-a11y/anchor-is-valid`: There is now some [documentation](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md#case-i-use-nextjs-and-im-getting-this-error-inside-of-links) on workarounds for Next.

`react/jsx-indent-props`: Not really needed because of prettier.