### PR TITLE
feat(config): remove rule spaced-comment

### DIFF
--- a/packages/eslint-config/configs/base.js
+++ b/packages/eslint-config/configs/base.js
@@ -299,14 +299,6 @@ module.exports = {
     'prefer-template': 'error',
     radix: 'error',
     'sort-imports': ['error', { ignoreCase: true, ignoreDeclarationSort: true }],
-    'spaced-comment': [
-      'error',
-      'always',
-      {
-        block: { balanced: true, exceptions: ['-', '+'], markers: ['=', '!'] },
-        line: { exceptions: ['-', '+'], markers: ['=', '!'] },
-      },
-    ],
     strict: 'error',
     'symbol-description': 'error',
     'valid-jsdoc': ['error', { requireParamDescription: false, requireReturnDescription: false }],

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -1671,33 +1671,6 @@ Object {
     "space-unary-word-ops": Array [
       "off",
     ],
-    "spaced-comment": Array [
-      "error",
-      "always",
-      Object {
-        "block": Object {
-          "balanced": true,
-          "exceptions": Array [
-            "-",
-            "+",
-          ],
-          "markers": Array [
-            "=",
-            "!",
-          ],
-        },
-        "line": Object {
-          "exceptions": Array [
-            "-",
-            "+",
-          ],
-          "markers": Array [
-            "=",
-            "!",
-          ],
-        },
-      },
-    ],
     "standard/array-bracket-even-spacing": Array [
       "off",
     ],
@@ -3448,33 +3421,6 @@ Object {
     "space-unary-word-ops": Array [
       "off",
     ],
-    "spaced-comment": Array [
-      "error",
-      "always",
-      Object {
-        "block": Object {
-          "balanced": true,
-          "exceptions": Array [
-            "-",
-            "+",
-          ],
-          "markers": Array [
-            "=",
-            "!",
-          ],
-        },
-        "line": Object {
-          "exceptions": Array [
-            "-",
-            "+",
-          ],
-          "markers": Array [
-            "=",
-            "!",
-          ],
-        },
-      },
-    ],
     "standard/array-bracket-even-spacing": Array [
       "off",
     ],
@@ -5223,33 +5169,6 @@ Object {
     ],
     "space-unary-word-ops": Array [
       "off",
-    ],
-    "spaced-comment": Array [
-      "error",
-      "always",
-      Object {
-        "block": Object {
-          "balanced": true,
-          "exceptions": Array [
-            "-",
-            "+",
-          ],
-          "markers": Array [
-            "=",
-            "!",
-          ],
-        },
-        "line": Object {
-          "exceptions": Array [
-            "-",
-            "+",
-          ],
-          "markers": Array [
-            "=",
-            "!",
-          ],
-        },
-      },
     ],
     "standard/array-bracket-even-spacing": Array [
       "off",
@@ -7284,33 +7203,6 @@ Object {
     ],
     "space-unary-word-ops": Array [
       "off",
-    ],
-    "spaced-comment": Array [
-      "error",
-      "always",
-      Object {
-        "block": Object {
-          "balanced": true,
-          "exceptions": Array [
-            "-",
-            "+",
-          ],
-          "markers": Array [
-            "=",
-            "!",
-          ],
-        },
-        "line": Object {
-          "exceptions": Array [
-            "-",
-            "+",
-          ],
-          "markers": Array [
-            "=",
-            "!",
-          ],
-        },
-      },
     ],
     "standard/array-bracket-even-spacing": Array [
       "off",
@@ -9377,33 +9269,6 @@ Object {
     ],
     "space-unary-word-ops": Array [
       "off",
-    ],
-    "spaced-comment": Array [
-      "error",
-      "always",
-      Object {
-        "block": Object {
-          "balanced": true,
-          "exceptions": Array [
-            "-",
-            "+",
-          ],
-          "markers": Array [
-            "=",
-            "!",
-          ],
-        },
-        "line": Object {
-          "exceptions": Array [
-            "-",
-            "+",
-          ],
-          "markers": Array [
-            "=",
-            "!",
-          ],
-        },
-      },
     ],
     "standard/array-bracket-even-spacing": Array [
       "off",


### PR DESCRIPTION
We format comments with prettier, we no longer need this rule.