### PR TITLE
Disallow getters/setters + switch case fallthrough fix

### DIFF
--- a/packages/eslint-config/configs/base.js
+++ b/packages/eslint-config/configs/base.js
@@ -241,6 +241,14 @@ module.exports = {
           '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
         selector: 'WithStatement',
       },
+      {
+        message: 'Property setters are not allowed',
+        selector: 'MethodDefinition[kind="set"]',
+      },
+      {
+        message: 'Property getters are not allowed',
+        selector: 'MethodDefinition[kind="get"]',
+      },
     ],
     'no-return-assign': ['error', 'except-parens'],
     'no-return-await': 'error',

--- a/packages/eslint-config/configs/base.js
+++ b/packages/eslint-config/configs/base.js
@@ -8,7 +8,7 @@ module.exports = {
     ecmaVersion: 2020,
     sourceType: 'module',
   },
-  plugins: ['import', 'gettext'],
+  plugins: ['import', 'gettext', 'switch-case'],
   reportUnusedDisableDirectives: true,
   rules: {
     'array-callback-return': 'error',
@@ -299,6 +299,11 @@ module.exports = {
         next: ['const', 'let', 'var'],
         prev: ['const', 'let', 'var'],
       },
+      {
+        blankLine: 'any',
+        next: ['case'],
+        prev: ['case'],
+      },
     ],
     'prefer-arrow-callback': ['error', { allowNamedFunctions: false, allowUnboundThis: true }],
     'prefer-const': ['error', { destructuring: 'any', ignoreReadBeforeAssign: true }],
@@ -316,6 +321,7 @@ module.exports = {
       },
     ],
     strict: 'error',
+    'switch-case/newline-between-switch-case': ['error', 'always', { fallthrough: 'never' }],
     'symbol-description': 'error',
     'valid-jsdoc': ['error', { requireParamDescription: false, requireReturnDescription: false }],
     'valid-typeof': ['error', { requireStringLiterals: true }],

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-switch-case": "^1.1.2",
     "prettier": "^2.2.1"
   },
   "devDependencies": {

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -19,6 +19,7 @@ Object {
     "sourceType": "module",
   },
   "plugins": Array [
+    "switch-case",
     "gettext",
     "import",
     "jsdoc",
@@ -1558,6 +1559,15 @@ Object {
           "var",
         ],
       },
+      Object {
+        "blankLine": "any",
+        "next": Array [
+          "case",
+        ],
+        "prev": Array [
+          "case",
+        ],
+      },
     ],
     "prefer-arrow-callback": Array [
       "off",
@@ -1895,6 +1905,13 @@ Object {
     "strict": Array [
       "error",
     ],
+    "switch-case/newline-between-switch-case": Array [
+      "error",
+      "always",
+      Object {
+        "fallthrough": "never",
+      },
+    ],
     "switch-colon-spacing": Array [
       "off",
     ],
@@ -2123,6 +2140,7 @@ Object {
     "sourceType": "module",
   },
   "plugins": Array [
+    "switch-case",
     "gettext",
     "import",
     "jsdoc",
@@ -3501,6 +3519,15 @@ Object {
           "var",
         ],
       },
+      Object {
+        "blankLine": "any",
+        "next": Array [
+          "case",
+        ],
+        "prev": Array [
+          "case",
+        ],
+      },
     ],
     "prefer-arrow-callback": Array [
       "off",
@@ -3819,6 +3846,13 @@ Object {
     ],
     "strict": Array [
       "error",
+    ],
+    "switch-case/newline-between-switch-case": Array [
+      "error",
+      "always",
+      Object {
+        "fallthrough": "never",
+      },
     ],
     "switch-colon-spacing": Array [
       "off",
@@ -4014,6 +4048,7 @@ Object {
     "sourceType": "module",
   },
   "plugins": Array [
+    "switch-case",
     "gettext",
     "import",
     "jsdoc",
@@ -5286,6 +5321,15 @@ Object {
           "var",
         ],
       },
+      Object {
+        "blankLine": "any",
+        "next": Array [
+          "case",
+        ],
+        "prev": Array [
+          "case",
+        ],
+      },
     ],
     "prefer-arrow-callback": Array [
       "off",
@@ -5604,6 +5648,13 @@ Object {
     ],
     "strict": Array [
       "error",
+    ],
+    "switch-case/newline-between-switch-case": Array [
+      "error",
+      "always",
+      Object {
+        "fallthrough": "never",
+      },
     ],
     "switch-colon-spacing": Array [
       "off",
@@ -5798,6 +5849,7 @@ Object {
     "sourceType": "module",
   },
   "plugins": Array [
+    "switch-case",
     "gettext",
     "import",
     "jsdoc",
@@ -7070,6 +7122,15 @@ Object {
           "var",
         ],
       },
+      Object {
+        "blankLine": "any",
+        "next": Array [
+          "case",
+        ],
+        "prev": Array [
+          "case",
+        ],
+      },
     ],
     "prefer-arrow-callback": Array [
       "off",
@@ -7388,6 +7449,13 @@ Object {
     ],
     "strict": Array [
       "error",
+    ],
+    "switch-case/newline-between-switch-case": Array [
+      "error",
+      "always",
+      Object {
+        "fallthrough": "never",
+      },
     ],
     "switch-colon-spacing": Array [
       "off",
@@ -7583,6 +7651,7 @@ Object {
     "sourceType": "module",
   },
   "plugins": Array [
+    "switch-case",
     "gettext",
     "import",
     "jsdoc",
@@ -9122,6 +9191,15 @@ Object {
           "var",
         ],
       },
+      Object {
+        "blankLine": "any",
+        "next": Array [
+          "case",
+        ],
+        "prev": Array [
+          "case",
+        ],
+      },
     ],
     "prefer-arrow-callback": Array [
       "off",
@@ -9457,6 +9535,13 @@ Object {
     ],
     "strict": Array [
       "error",
+    ],
+    "switch-case/newline-between-switch-case": Array [
+      "error",
+      "always",
+      Object {
+        "fallthrough": "never",
+      },
     ],
     "switch-colon-spacing": Array [
       "off",
@@ -9684,6 +9769,7 @@ Object {
     "sourceType": "module",
   },
   "plugins": Array [
+    "switch-case",
     "gettext",
     "import",
     "jsdoc",
@@ -11223,6 +11309,15 @@ Object {
           "var",
         ],
       },
+      Object {
+        "blankLine": "any",
+        "next": Array [
+          "case",
+        ],
+        "prev": Array [
+          "case",
+        ],
+      },
     ],
     "prefer-arrow-callback": Array [
       "off",
@@ -11558,6 +11653,13 @@ Object {
     ],
     "strict": Array [
       "error",
+    ],
+    "switch-case/newline-between-switch-case": Array [
+      "error",
+      "always",
+      Object {
+        "fallthrough": "never",
+      },
     ],
     "switch-colon-spacing": Array [
       "off",

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -1316,6 +1316,14 @@ Object {
         "message": "\`with\` is disallowed in strict mode because it makes code impossible to predict and optimize.",
         "selector": "WithStatement",
       },
+      Object {
+        "message": "Property setters are not allowed",
+        "selector": "MethodDefinition[kind=\\"set\\"]",
+      },
+      Object {
+        "message": "Property getters are not allowed",
+        "selector": "MethodDefinition[kind=\\"get\\"]",
+      },
     ],
     "no-return-assign": Array [
       "error",
@@ -3254,6 +3262,14 @@ Object {
         "message": "\`with\` is disallowed in strict mode because it makes code impossible to predict and optimize.",
         "selector": "WithStatement",
       },
+      Object {
+        "message": "Property setters are not allowed",
+        "selector": "MethodDefinition[kind=\\"set\\"]",
+      },
+      Object {
+        "message": "Property getters are not allowed",
+        "selector": "MethodDefinition[kind=\\"get\\"]",
+      },
     ],
     "no-return-assign": Array [
       "error",
@@ -5031,6 +5047,14 @@ Object {
         "message": "\`with\` is disallowed in strict mode because it makes code impossible to predict and optimize.",
         "selector": "WithStatement",
       },
+      Object {
+        "message": "Property setters are not allowed",
+        "selector": "MethodDefinition[kind=\\"set\\"]",
+      },
+      Object {
+        "message": "Property getters are not allowed",
+        "selector": "MethodDefinition[kind=\\"get\\"]",
+      },
     ],
     "no-return-assign": Array [
       "error",
@@ -6806,6 +6830,14 @@ Object {
       Object {
         "message": "\`with\` is disallowed in strict mode because it makes code impossible to predict and optimize.",
         "selector": "WithStatement",
+      },
+      Object {
+        "message": "Property setters are not allowed",
+        "selector": "MethodDefinition[kind=\\"set\\"]",
+      },
+      Object {
+        "message": "Property getters are not allowed",
+        "selector": "MethodDefinition[kind=\\"get\\"]",
       },
     ],
     "no-return-assign": Array [
@@ -8847,6 +8879,14 @@ Object {
       Object {
         "message": "\`with\` is disallowed in strict mode because it makes code impossible to predict and optimize.",
         "selector": "WithStatement",
+      },
+      Object {
+        "message": "Property setters are not allowed",
+        "selector": "MethodDefinition[kind=\\"set\\"]",
+      },
+      Object {
+        "message": "Property getters are not allowed",
+        "selector": "MethodDefinition[kind=\\"get\\"]",
       },
     ],
     "no-return-assign": Array [
@@ -10940,6 +10980,14 @@ Object {
       Object {
         "message": "\`with\` is disallowed in strict mode because it makes code impossible to predict and optimize.",
         "selector": "WithStatement",
+      },
+      Object {
+        "message": "Property setters are not allowed",
+        "selector": "MethodDefinition[kind=\\"set\\"]",
+      },
+      Object {
+        "message": "Property getters are not allowed",
+        "selector": "MethodDefinition[kind=\\"get\\"]",
       },
     ],
     "no-return-assign": Array [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2999,6 +2999,14 @@ eslint-plugin-react@^7.23.2:
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.5"
 
+eslint-plugin-switch-case@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-switch-case/-/eslint-plugin-switch-case-1.1.2.tgz#a622db0c4c440828526b6f26f000d71e74850032"
+  integrity sha1-piLbDExECChSa28m8ADXHnSFADI=
+  dependencies:
+    lodash.last "^3.0.0"
+    lodash.zipobject "^4.0.0"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -4755,6 +4763,11 @@ lodash.ismatch@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
 
+lodash.last@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.last/-/lodash.last-3.0.0.tgz#242f663112dd4c6e63728c60a3c909d1bdadbd4c"
+  integrity sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw=
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -4779,6 +4792,11 @@ lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
+
+lodash.zipobject@^4.0.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz#b399f5aba8ff62a746f6979bf20b214f964dbef8"
+  integrity sha1-s5n1q6j/YqdG9peb8gshT5ZNvvg=
 
 lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"


### PR DESCRIPTION
**feat(config): disallow getters and setters**
Missed this one when porting the config over.

**fix(config): switch case fallthrough no longer requires a linebreak**
We had a bug where the following will require a linebreak between the following pass-through cases:
```js
switch(name) {
  case 'daniel':
  case 'dan': {
  }
}
```

Tried fixing it only with `adding-line-between-statements` by setting the config to something like:
```js
{
    blankLine: 'never',
    next: ['case'],
    prev: ['case'],
},
{
    blankLine: 'always',
    next: ['case'],
    prev: ['block-like'],
},
```

But that didn't work for multi-line non-blocks `cases`, had to add a plugin.