### PR TITLE
feat(config): stylistic rules are now warnings

### DIFF
--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,5 +1,3 @@
-# v2 - wip
-
 # @bigcommerce/eslint-config
 
 This package is a configuration preset for [ESLint](https://eslint.org/).
@@ -33,7 +31,11 @@ This config also runs prettier via eslint, add the following to your `package.js
 }
 ```
 
-If possible, try not to override the preset unless you have a special reason.
+Stylistic rules are considered `warnings` for better developer experience, however, we recommend
+running CI with:
+```
+eslint --max-warnings 0
+```
 
 ## Release
 

--- a/packages/eslint-config/configs/base.js
+++ b/packages/eslint-config/configs/base.js
@@ -38,7 +38,7 @@ module.exports = {
         tsx: 'never',
       },
     ],
-    'import/newline-after-import': 'error',
+    'import/newline-after-import': 'warn',
     'import/no-absolute-path': 'error',
     'import/no-amd': 'error',
     'import/no-dynamic-require': 'error',
@@ -48,7 +48,7 @@ module.exports = {
     'import/no-unresolved': ['error', { caseSensitive: true, commonjs: true }],
     'import/no-webpack-loader-syntax': 'error',
     'import/order': [
-      'error',
+      'warn',
       {
         alphabetize: { caseInsensitive: true, order: 'asc' },
         groups: [['builtin', 'external'], 'internal', 'parent', 'sibling', 'index'],
@@ -256,7 +256,6 @@ module.exports = {
     'no-self-compare': 'error',
     'no-sequences': 'error',
     'no-shadow': ['error', { hoist: 'all' }],
-    'no-spaced-func': 'error',
     'no-template-curly-in-string': 'error',
     'no-undef-init': 'error',
     'no-underscore-dangle': ['error', { allowAfterSuper: true, allowAfterThis: true }],
@@ -278,7 +277,7 @@ module.exports = {
     'one-var': ['error', 'never'],
     'operator-assignment': ['error', 'always'],
     'padding-line-between-statements': [
-      'error',
+      'warn',
       {
         blankLine: 'always',
         next: 'return',
@@ -313,7 +312,7 @@ module.exports = {
     radix: 'error',
     'sort-imports': ['error', { ignoreCase: true, ignoreDeclarationSort: true }],
     'spaced-comment': [
-      'error',
+      'warn',
       'always',
       {
         block: { balanced: true, exceptions: ['-', '+'], markers: ['=', '!'] },
@@ -321,7 +320,7 @@ module.exports = {
       },
     ],
     strict: 'error',
-    'switch-case/newline-between-switch-case': ['error', 'always', { fallthrough: 'never' }],
+    'switch-case/newline-between-switch-case': ['warn', 'always', { fallthrough: 'never' }],
     'symbol-description': 'error',
     'valid-jsdoc': ['error', { requireParamDescription: false, requireReturnDescription: false }],
     'valid-typeof': ['error', { requireStringLiterals: true }],

--- a/packages/eslint-config/configs/jest.js
+++ b/packages/eslint-config/configs/jest.js
@@ -12,7 +12,7 @@ module.exports = {
         optionalDependencies: false,
       },
     ],
-    'jest-formatting/padding-around-all': 'error',
+    'jest-formatting/padding-around-all': 'warn',
     'jest/no-done-callback': 'off',
     'jest/no-duplicate-hooks': 'off',
     'jest/no-if': 'error',

--- a/packages/eslint-config/configs/prettier.js
+++ b/packages/eslint-config/configs/prettier.js
@@ -25,7 +25,7 @@ function getRules() {
   }
 
   return {
-    'prettier/prettier': ['error', defaultConfig, { usePrettierrc: false }],
+    'prettier/prettier': ['warn', defaultConfig, { usePrettierrc: false }],
   };
 }
 

--- a/packages/eslint-config/configs/react.js
+++ b/packages/eslint-config/configs/react.js
@@ -19,7 +19,7 @@ module.exports = {
     'react/jsx-no-bind': 'error',
     'react/jsx-no-useless-fragment': 'error',
     'react/jsx-pascal-case': 'error',
-    'react/jsx-sort-props': 'error',
+    'react/jsx-sort-props': 'warn',
     'react/no-redundant-should-component-update': 'error',
     'react/no-this-in-sfc': 'error',
     'react/no-unsafe': 'error',

--- a/packages/eslint-config/configs/typescript.js
+++ b/packages/eslint-config/configs/typescript.js
@@ -145,7 +145,7 @@ module.exports = {
       files: ['**/*.d.ts'],
       rules: {
         'spaced-comment': [
-          'error',
+          'warn',
           'always',
           {
             block: { balanced: true, exceptions: ['-', '+'], markers: ['=', '!'] },

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -542,7 +542,7 @@ Object {
       2,
     ],
     "import/newline-after-import": Array [
-      "error",
+      "warn",
     ],
     "import/no-absolute-path": Array [
       "error",
@@ -582,7 +582,7 @@ Object {
       "error",
     ],
     "import/order": Array [
-      "error",
+      "warn",
       Object {
         "alphabetize": Object {
           "caseInsensitive": true,
@@ -1516,7 +1516,7 @@ Object {
       "off",
     ],
     "padding-line-between-statements": Array [
-      "error",
+      "warn",
       Object {
         "blankLine": "always",
         "next": "return",
@@ -1596,7 +1596,7 @@ Object {
       "error",
     ],
     "prettier/prettier": Array [
-      "error",
+      "warn",
       Object {
         "printWidth": 100,
         "singleQuote": true,
@@ -1703,7 +1703,7 @@ Object {
       "off",
     ],
     "react/jsx-sort-props": Array [
-      "error",
+      "warn",
     ],
     "react/jsx-space-before-closing": Array [
       "off",
@@ -1850,7 +1850,7 @@ Object {
       "off",
     ],
     "spaced-comment": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "block": Object {
@@ -1890,7 +1890,7 @@ Object {
       "error",
     ],
     "switch-case/newline-between-switch-case": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "fallthrough": "never",
@@ -2385,7 +2385,7 @@ Object {
       2,
     ],
     "import/newline-after-import": Array [
-      "error",
+      "warn",
     ],
     "import/no-absolute-path": Array [
       "error",
@@ -2429,7 +2429,7 @@ Object {
       "error",
     ],
     "import/order": Array [
-      "error",
+      "warn",
       Object {
         "alphabetize": Object {
           "caseInsensitive": true,
@@ -2456,7 +2456,7 @@ Object {
       "off",
     ],
     "jest-formatting/padding-around-all": Array [
-      "error",
+      "warn",
     ],
     "jest/expect-expect": Array [
       "warn",
@@ -3460,7 +3460,7 @@ Object {
       "off",
     ],
     "padding-line-between-statements": Array [
-      "error",
+      "warn",
       Object {
         "blankLine": "always",
         "next": "return",
@@ -3537,7 +3537,7 @@ Object {
       "error",
     ],
     "prettier/prettier": Array [
-      "error",
+      "warn",
       Object {
         "printWidth": 100,
         "singleQuote": true,
@@ -3636,7 +3636,7 @@ Object {
       "off",
     ],
     "react/jsx-sort-props": Array [
-      "error",
+      "warn",
     ],
     "react/jsx-space-before-closing": Array [
       "off",
@@ -3777,7 +3777,7 @@ Object {
       "off",
     ],
     "spaced-comment": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "block": Object {
@@ -3816,7 +3816,7 @@ Object {
       "error",
     ],
     "switch-case/newline-between-switch-case": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "fallthrough": "never",
@@ -4275,7 +4275,7 @@ Object {
       2,
     ],
     "import/newline-after-import": Array [
-      "error",
+      "warn",
     ],
     "import/no-absolute-path": Array [
       "error",
@@ -4315,7 +4315,7 @@ Object {
       "error",
     ],
     "import/order": Array [
-      "error",
+      "warn",
       Object {
         "alphabetize": Object {
           "caseInsensitive": true,
@@ -5246,7 +5246,7 @@ Object {
       "off",
     ],
     "padding-line-between-statements": Array [
-      "error",
+      "warn",
       Object {
         "blankLine": "always",
         "next": "return",
@@ -5323,7 +5323,7 @@ Object {
       "error",
     ],
     "prettier/prettier": Array [
-      "error",
+      "warn",
       Object {
         "printWidth": 100,
         "singleQuote": true,
@@ -5422,7 +5422,7 @@ Object {
       "off",
     ],
     "react/jsx-sort-props": Array [
-      "error",
+      "warn",
     ],
     "react/jsx-space-before-closing": Array [
       "off",
@@ -5563,7 +5563,7 @@ Object {
       "off",
     ],
     "spaced-comment": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "block": Object {
@@ -5602,7 +5602,7 @@ Object {
       "error",
     ],
     "switch-case/newline-between-switch-case": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "fallthrough": "never",
@@ -6060,7 +6060,7 @@ Object {
       2,
     ],
     "import/newline-after-import": Array [
-      "error",
+      "warn",
     ],
     "import/no-absolute-path": Array [
       "error",
@@ -6100,7 +6100,7 @@ Object {
       "error",
     ],
     "import/order": Array [
-      "error",
+      "warn",
       Object {
         "alphabetize": Object {
           "caseInsensitive": true,
@@ -7031,7 +7031,7 @@ Object {
       "off",
     ],
     "padding-line-between-statements": Array [
-      "error",
+      "warn",
       Object {
         "blankLine": "always",
         "next": "return",
@@ -7108,7 +7108,7 @@ Object {
       "error",
     ],
     "prettier/prettier": Array [
-      "error",
+      "warn",
       Object {
         "printWidth": 100,
         "singleQuote": true,
@@ -7207,7 +7207,7 @@ Object {
       "off",
     ],
     "react/jsx-sort-props": Array [
-      "error",
+      "warn",
     ],
     "react/jsx-space-before-closing": Array [
       "off",
@@ -7348,7 +7348,7 @@ Object {
       "off",
     ],
     "spaced-comment": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "block": Object {
@@ -7387,7 +7387,7 @@ Object {
       "error",
     ],
     "switch-case/newline-between-switch-case": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "fallthrough": "never",
@@ -8110,7 +8110,7 @@ Object {
       2,
     ],
     "import/newline-after-import": Array [
-      "error",
+      "warn",
     ],
     "import/no-absolute-path": Array [
       "error",
@@ -8150,7 +8150,7 @@ Object {
       "error",
     ],
     "import/order": Array [
-      "error",
+      "warn",
       Object {
         "alphabetize": Object {
           "caseInsensitive": true,
@@ -9084,7 +9084,7 @@ Object {
       "off",
     ],
     "padding-line-between-statements": Array [
-      "error",
+      "warn",
       Object {
         "blankLine": "always",
         "next": "return",
@@ -9164,7 +9164,7 @@ Object {
       "error",
     ],
     "prettier/prettier": Array [
-      "error",
+      "warn",
       Object {
         "printWidth": 100,
         "singleQuote": true,
@@ -9271,7 +9271,7 @@ Object {
       "off",
     ],
     "react/jsx-sort-props": Array [
-      "error",
+      "warn",
     ],
     "react/jsx-space-before-closing": Array [
       "off",
@@ -9418,7 +9418,7 @@ Object {
       "off",
     ],
     "spaced-comment": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "block": Object {
@@ -9457,7 +9457,7 @@ Object {
       "error",
     ],
     "switch-case/newline-between-switch-case": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "fallthrough": "never",
@@ -10212,7 +10212,7 @@ Object {
       2,
     ],
     "import/newline-after-import": Array [
-      "error",
+      "warn",
     ],
     "import/no-absolute-path": Array [
       "error",
@@ -10252,7 +10252,7 @@ Object {
       "error",
     ],
     "import/order": Array [
-      "error",
+      "warn",
       Object {
         "alphabetize": Object {
           "caseInsensitive": true,
@@ -11186,7 +11186,7 @@ Object {
       "off",
     ],
     "padding-line-between-statements": Array [
-      "error",
+      "warn",
       Object {
         "blankLine": "always",
         "next": "return",
@@ -11266,7 +11266,7 @@ Object {
       "error",
     ],
     "prettier/prettier": Array [
-      "error",
+      "warn",
       Object {
         "printWidth": 100,
         "singleQuote": true,
@@ -11373,7 +11373,7 @@ Object {
       "off",
     ],
     "react/jsx-sort-props": Array [
-      "error",
+      "warn",
     ],
     "react/jsx-space-before-closing": Array [
       "off",
@@ -11520,7 +11520,7 @@ Object {
       "off",
     ],
     "spaced-comment": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "block": Object {
@@ -11559,7 +11559,7 @@ Object {
       "error",
     ],
     "switch-case/newline-between-switch-case": Array [
-      "error",
+      "warn",
       "always",
       Object {
         "fallthrough": "never",


### PR DESCRIPTION
Changed stylistic rules from `error` -> `warn`. We think this will give a better developer experience:

Error = Pay attention to this, you may need to change something.
Warn = Stylistic change, probably will be auto-fixed.