### PR TITLE
fix(config): move jsx-file-extension rule to react config

### DIFF
--- a/packages/eslint-config/configs/react.js
+++ b/packages/eslint-config/configs/react.js
@@ -35,4 +35,13 @@ module.exports = {
       version: 'detect',
     },
   },
+  // eslint-disable-next-line sort-keys
+  overrides: [
+    {
+      files: ['**/*.ts'],
+      rules: {
+        'react/jsx-filename-extension': [1, { extensions: ['.tsx'] }],
+      },
+    },
+  ],
 };

--- a/packages/eslint-config/configs/typescript.js
+++ b/packages/eslint-config/configs/typescript.js
@@ -127,7 +127,6 @@ module.exports = {
     'no-unused-vars': 'off',
     'no-use-before-define': 'off',
     'no-useless-constructor': 'off',
-    'react/jsx-filename-extension': [1, { extensions: ['.tsx'] }],
     'sort-keys': 'off',
   },
   settings: {

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -11315,14 +11315,6 @@ Object {
     "react/jsx-equals-spacing": Array [
       "off",
     ],
-    "react/jsx-filename-extension": Array [
-      1,
-      Object {
-        "extensions": Array [
-          ".tsx",
-        ],
-      },
-    ],
     "react/jsx-first-prop-new-line": Array [
       "off",
     ],


### PR DESCRIPTION
We have a `react/` rule in our eslint-ts config. @chanceaclark found about this bug on a non-react ts repo. Since we don't load the react plugin it crashed.