### PR TITLE
Enable @typescript-eslint/no-unnecessary-condition

### DIFF
--- a/packages/eslint-config/configs/typescript.js
+++ b/packages/eslint-config/configs/typescript.js
@@ -96,6 +96,7 @@ module.exports = {
     ],
     '@typescript-eslint/no-shadow': ['error', { hoist: 'all' }],
     '@typescript-eslint/no-throw-literal': ['error'],
+    '@typescript-eslint/no-unnecessary-condition': 'error',
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',
     '@typescript-eslint/no-unused-expressions': 'error',
     '@typescript-eslint/no-unused-vars': [

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -255,6 +255,9 @@ Object {
     "@typescript-eslint/no-throw-literal": Array [
       "error",
     ],
+    "@typescript-eslint/no-unnecessary-condition": Array [
+      "error",
+    ],
     "@typescript-eslint/no-unnecessary-type-assertion": Array [
       "error",
     ],
@@ -7823,6 +7826,9 @@ Object {
     "@typescript-eslint/no-throw-literal": Array [
       "error",
     ],
+    "@typescript-eslint/no-unnecessary-condition": Array [
+      "error",
+    ],
     "@typescript-eslint/no-unnecessary-type-assertion": Array [
       "error",
     ],
@@ -9923,6 +9929,9 @@ Object {
       "error",
     ],
     "@typescript-eslint/no-throw-literal": Array [
+      "error",
+    ],
+    "@typescript-eslint/no-unnecessary-condition": Array [
       "error",
     ],
     "@typescript-eslint/no-unnecessary-type-assertion": Array [


### PR DESCRIPTION
Enable `@typescript-eslint/no-unnecessary-condition` to avoid unnecessary checks
It might also hint when types are not defined correctly. It will point out we are trying to check for something to exist, which might indicate the type is not reflecting the fact that it might not be defined.

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md