### PR TITLE
fix(config): disable jsx-a11y/no-onchange

### DIFF
--- a/packages/eslint-config/configs/react.js
+++ b/packages/eslint-config/configs/react.js
@@ -11,6 +11,8 @@ module.exports = {
   },
   plugins: ['react-hooks'],
   rules: {
+    // Remove when https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/757 gets released
+    'jsx-a11y/no-onchange': 'off',
     'react-hooks/exhaustive-deps': 'error',
     'react-hooks/rules-of-hooks': 'error',
     'react/destructuring-assignment': 'error',

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -841,7 +841,7 @@ Object {
       },
     ],
     "jsx-a11y/no-onchange": Array [
-      "error",
+      "off",
     ],
     "jsx-a11y/no-redundant-roles": Array [
       "error",
@@ -2788,7 +2788,7 @@ Object {
       },
     ],
     "jsx-a11y/no-onchange": Array [
-      "error",
+      "off",
     ],
     "jsx-a11y/no-redundant-roles": Array [
       "error",
@@ -4574,7 +4574,7 @@ Object {
       },
     ],
     "jsx-a11y/no-onchange": Array [
-      "error",
+      "off",
     ],
     "jsx-a11y/no-redundant-roles": Array [
       "error",
@@ -6359,7 +6359,7 @@ Object {
       },
     ],
     "jsx-a11y/no-onchange": Array [
-      "error",
+      "off",
     ],
     "jsx-a11y/no-redundant-roles": Array [
       "error",
@@ -8409,7 +8409,7 @@ Object {
       },
     ],
     "jsx-a11y/no-onchange": Array [
-      "error",
+      "off",
     ],
     "jsx-a11y/no-redundant-roles": Array [
       "error",
@@ -10511,7 +10511,7 @@ Object {
       },
     ],
     "jsx-a11y/no-onchange": Array [
-      "error",
+      "off",
     ],
     "jsx-a11y/no-redundant-roles": Array [
       "error",


### PR DESCRIPTION
This rule has been deprecated and removed from the `recommended` rules on https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/757.

More context on: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/398

Left a comment to remove it once it gets released.
