### PR TITLE
feat(config): allow arrow functions react/jsx-no-bind

### DIFF
--- a/packages/eslint-config/configs/react.js
+++ b/packages/eslint-config/configs/react.js
@@ -21,7 +21,12 @@ module.exports = {
     'react/destructuring-assignment': 'error',
     'react/display-name': 'off',
     'react/jsx-fragments': ['error', 'syntax'],
-    'react/jsx-no-bind': 'error',
+    'react/jsx-no-bind': [
+      'error',
+      {
+        allowArrowFunctions: true,
+      },
+    ],
     'react/jsx-no-useless-fragment': 'error',
     'react/jsx-pascal-case': 'error',
     'react/jsx-sort-props': 'warn',

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -1714,6 +1714,13 @@ Object {
     ],
     "react/jsx-no-bind": Array [
       "error",
+      Object {
+        "allowArrowFunctions": true,
+        "allowBind": false,
+        "allowFunctions": false,
+        "ignoreDOMComponents": false,
+        "ignoreRefs": false,
+      },
     ],
     "react/jsx-no-comment-textnodes": Array [
       2,
@@ -3684,6 +3691,13 @@ Object {
     ],
     "react/jsx-no-bind": Array [
       "error",
+      Object {
+        "allowArrowFunctions": true,
+        "allowBind": false,
+        "allowFunctions": false,
+        "ignoreDOMComponents": false,
+        "ignoreRefs": false,
+      },
     ],
     "react/jsx-no-comment-textnodes": Array [
       2,
@@ -5507,6 +5521,13 @@ Object {
     ],
     "react/jsx-no-bind": Array [
       "error",
+      Object {
+        "allowArrowFunctions": true,
+        "allowBind": false,
+        "allowFunctions": false,
+        "ignoreDOMComponents": false,
+        "ignoreRefs": false,
+      },
     ],
     "react/jsx-no-comment-textnodes": Array [
       2,
@@ -7329,6 +7350,13 @@ Object {
     ],
     "react/jsx-no-bind": Array [
       "error",
+      Object {
+        "allowArrowFunctions": true,
+        "allowBind": false,
+        "allowFunctions": false,
+        "ignoreDOMComponents": false,
+        "ignoreRefs": false,
+      },
     ],
     "react/jsx-no-comment-textnodes": Array [
       2,
@@ -9430,6 +9458,13 @@ Object {
     ],
     "react/jsx-no-bind": Array [
       "error",
+      Object {
+        "allowArrowFunctions": true,
+        "allowBind": false,
+        "allowFunctions": false,
+        "ignoreDOMComponents": false,
+        "ignoreRefs": false,
+      },
     ],
     "react/jsx-no-comment-textnodes": Array [
       2,
@@ -11561,6 +11596,13 @@ Object {
     ],
     "react/jsx-no-bind": Array [
       "error",
+      Object {
+        "allowArrowFunctions": true,
+        "allowBind": false,
+        "allowFunctions": false,
+        "ignoreDOMComponents": false,
+        "ignoreRefs": false,
+      },
     ],
     "react/jsx-no-comment-textnodes": Array [
       2,


### PR DESCRIPTION
This rule is not recommended by the react team and in a lot of cases might have performance issues.