### PR TITLE
feat(config): FE-00 unescaped entities denylist

### DIFF
--- a/packages/eslint-config/configs/react.js
+++ b/packages/eslint-config/configs/react.js
@@ -29,6 +29,15 @@ module.exports = {
     'react/jsx-sort-props': 'warn',
     'react/no-redundant-should-component-update': 'error',
     'react/no-this-in-sfc': 'error',
+    'react/no-unescaped-entities': [
+      'error',
+      {
+        forbid: [
+          { alternatives: ['&gt;'], char: '>' },
+          { alternatives: ['&#125;'], char: '}' },
+        ],
+      },
+    ],
     'react/no-unsafe': 'error',
     'react/no-unused-state': 'error',
     'react/prefer-es6-class': 'error',

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -1840,7 +1840,23 @@ Object {
       "error",
     ],
     "react/no-unescaped-entities": Array [
-      2,
+      "error",
+      Object {
+        "forbid": Array [
+          Object {
+            "alternatives": Array [
+              "&gt;",
+            ],
+            "char": ">",
+          },
+          Object {
+            "alternatives": Array [
+              "&#125;",
+            ],
+            "char": "}",
+          },
+        ],
+      },
     ],
     "react/no-unknown-property": Array [
       2,
@@ -3788,7 +3804,23 @@ Object {
       "error",
     ],
     "react/no-unescaped-entities": Array [
-      2,
+      "error",
+      Object {
+        "forbid": Array [
+          Object {
+            "alternatives": Array [
+              "&gt;",
+            ],
+            "char": ">",
+          },
+          Object {
+            "alternatives": Array [
+              "&#125;",
+            ],
+            "char": "}",
+          },
+        ],
+      },
     ],
     "react/no-unknown-property": Array [
       2,
@@ -5598,7 +5630,23 @@ Object {
       "error",
     ],
     "react/no-unescaped-entities": Array [
-      2,
+      "error",
+      Object {
+        "forbid": Array [
+          Object {
+            "alternatives": Array [
+              "&gt;",
+            ],
+            "char": ">",
+          },
+          Object {
+            "alternatives": Array [
+              "&#125;",
+            ],
+            "char": "}",
+          },
+        ],
+      },
     ],
     "react/no-unknown-property": Array [
       2,
@@ -7407,7 +7455,23 @@ Object {
       "error",
     ],
     "react/no-unescaped-entities": Array [
-      2,
+      "error",
+      Object {
+        "forbid": Array [
+          Object {
+            "alternatives": Array [
+              "&gt;",
+            ],
+            "char": ">",
+          },
+          Object {
+            "alternatives": Array [
+              "&#125;",
+            ],
+            "char": "}",
+          },
+        ],
+      },
     ],
     "react/no-unknown-property": Array [
       2,
@@ -9560,7 +9624,23 @@ Object {
       "error",
     ],
     "react/no-unescaped-entities": Array [
-      2,
+      "error",
+      Object {
+        "forbid": Array [
+          Object {
+            "alternatives": Array [
+              "&gt;",
+            ],
+            "char": ">",
+          },
+          Object {
+            "alternatives": Array [
+              "&#125;",
+            ],
+            "char": "}",
+          },
+        ],
+      },
     ],
     "react/no-unknown-property": Array [
       2,
@@ -11740,7 +11820,23 @@ Object {
       "error",
     ],
     "react/no-unescaped-entities": Array [
-      2,
+      "error",
+      Object {
+        "forbid": Array [
+          Object {
+            "alternatives": Array [
+              "&gt;",
+            ],
+            "char": ">",
+          },
+          Object {
+            "alternatives": Array [
+              "&#125;",
+            ],
+            "char": "}",
+          },
+        ],
+      },
     ],
     "react/no-unknown-property": Array [
       2,


### PR DESCRIPTION
Forgot to loosen up this rule a little bit. We have this rule with the same config in a couple of repos. Restricting `'` and `"` is a bit too much IMO.

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md