### PR TITLE
fix(config): FE-00 incorrect entrypoint

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -2,7 +2,7 @@
   "name": "@bigcommerce/eslint-config",
   "version": "2.3.0",
   "description": "Default ESLint configuration used at BigCommerce",
-  "main": "index.json",
+  "main": "index.js",
   "files": [
     "index.js",
     "configs",


### PR DESCRIPTION
Our config used to be a `.json` then we changed it to `.js` and forgot to update it here. Luckily, node defaults to `index.js` so it didn't break, however, the default is being deprecated.