### PR TITLE
feat(config): FE-00 disable default-case for ts files

### DIFF
--- a/packages/eslint-config/configs/typescript.js
+++ b/packages/eslint-config/configs/typescript.js
@@ -147,6 +147,7 @@ module.exports = {
     // @typescript-eslint version
     camelcase: 'off',
     'consistent-return': 'off',
+    'default-case': 'off',
     'default-param-last': 'off',
     'import/named': 'off',
     'no-duplicate-imports': 'off',

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -487,7 +487,7 @@ Object {
       0,
     ],
     "default-case": Array [
-      "error",
+      "off",
     ],
     "default-param-last": Array [
       "off",
@@ -8271,7 +8271,7 @@ Object {
       0,
     ],
     "default-case": Array [
-      "error",
+      "off",
     ],
     "default-param-last": Array [
       "off",
@@ -10475,7 +10475,7 @@ Object {
       0,
     ],
     "default-case": Array [
-      "error",
+      "off",
     ],
     "default-param-last": Array [
       "off",


### PR DESCRIPTION
Currently, we enforce a the [default-case](https://eslint.org/docs/rules/default-case) rule for switches. Basically it enforces all switches to have a `default` case.

This rule makes sense when working with `js` as there is no way to make sure all cases are being handled, it is "safer" to have an explicit default.

However, in TS we have [@typescript-eslint/switch-exhaustiveness-check](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.md#switch-exhaustiveness-check) which is enabled in our config.

Let's take a look at the following example:
```ts
type Animal = 'cat' | 'dog';

const sayHi = (animal: Animal): string => {
  switch(animal) {
    case 'cat':
      return 'Purr Purr';
    case 'dog':
      return 'Woof woof';
    default:
      return `Hello ${animal}`;
      // Or throw an error
  }
};
```

With `default-case` we are forced to add a `default` here. We have a couple of options:
- Have a default work as a fallback
- Throw an error
- Add a `// no default` comment that bypasses the `default-case` rule.


However, if we change our type definition to:
```ts
type Animal = 'cat' | 'dog' | 'bird';
```

We won't get any lint errors in our switch, and our app is not properly handling `'bird'`.

If we remove `default-case` and remove the default from our code:

```ts
const sayHi = (animal: Animal): string => {
  switch(animal) {
    case 'cat':
      return 'Purr Purr';
    case 'dog':
      return 'Woof woof';
  }
};
```

As soon as we add a new animal, `@typescript-eslint/switch-exhaustiveness-check` will be triggered and we will have to add the new `case 'bird':` to our switch.

In scenarios where you do want a `default` in the switch, that is fine, you can still add it, but it would now be optional in ts(x) files.

@bigcommerce/frontend 