### PR TITLE
feat(config): FE-00 add curly rule

### DIFF
--- a/packages/eslint-config/configs/prettier.js
+++ b/packages/eslint-config/configs/prettier.js
@@ -25,6 +25,7 @@ function getRules() {
   }
 
   return {
+    "curly": ["error", "all"],
     'prettier/prettier': ['warn', defaultConfig, { usePrettierrc: false }],
   };
 }

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -484,7 +484,8 @@ Object {
       "off",
     ],
     "curly": Array [
-      0,
+      "error",
+      "all",
     ],
     "default-case": Array [
       "off",
@@ -2364,7 +2365,8 @@ Object {
       "error",
     ],
     "curly": Array [
-      0,
+      "error",
+      "all",
     ],
     "default-case": Array [
       "error",
@@ -4288,7 +4290,8 @@ Object {
       "error",
     ],
     "curly": Array [
-      0,
+      "error",
+      "all",
     ],
     "default-case": Array [
       "error",
@@ -6113,7 +6116,8 @@ Object {
       "error",
     ],
     "curly": Array [
-      0,
+      "error",
+      "all",
     ],
     "default-case": Array [
       "error",
@@ -8268,7 +8272,8 @@ Object {
       "off",
     ],
     "curly": Array [
-      0,
+      "error",
+      "all",
     ],
     "default-case": Array [
       "off",
@@ -10472,7 +10477,8 @@ Object {
       "off",
     ],
     "curly": Array [
-      0,
+      "error",
+      "all",
     ],
     "default-case": Array [
       "off",


### PR DESCRIPTION
## What/Why

Enables the [`curly`](https://eslint.org/docs/rules/curly) rule. This is opinionated, but I'd like for us to keep consistency when writing conditionals/loops. It encourages "encapsulation" of logic and readability within blocks of code, rather than "being clever" with a one-liner.

We originally had this rule before we added Prettier. Prettier [disables this rule](https://github.com/prettier/eslint-config-prettier/blob/ab47f025c03b3091dce6dca0f3d785b11c7ec3ed/index.js#L10) so we need to add this back in via [their instructions](https://github.com/prettier/eslint-config-prettier#curly).

For instance,
```ts
if (something) {
  doSomething();
}
```
is more readable than
```ts
if (something) doSomething();
```