### PR TITLE
fix(config): FE-00 Ignore naming convention for objectLiteralProperty and typeProperty

### DIFF
--- a/packages/eslint-config/configs/typescript.js
+++ b/packages/eslint-config/configs/typescript.js
@@ -85,6 +85,11 @@ module.exports = {
         modifiers: ['unused'],
         selector: 'parameter',
       },
+      {
+        format: null,
+        modifiers: ['requiresQuotes'],
+        selector: ['objectLiteralProperty', 'typeProperty'],
+      },
     ],
     '@typescript-eslint/no-duplicate-imports': 'error',
     '@typescript-eslint/no-explicit-any': 'error',

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -188,6 +188,16 @@ Object {
         ],
         "selector": "parameter",
       },
+      Object {
+        "format": null,
+        "modifiers": Array [
+          "requiresQuotes",
+        ],
+        "selector": Array [
+          "objectLiteralProperty",
+          "typeProperty",
+        ],
+      },
     ],
     "@typescript-eslint/no-array-constructor": Array [
       "error",
@@ -8008,6 +8018,16 @@ Object {
         ],
         "selector": "parameter",
       },
+      Object {
+        "format": null,
+        "modifiers": Array [
+          "requiresQuotes",
+        ],
+        "selector": Array [
+          "objectLiteralProperty",
+          "typeProperty",
+        ],
+      },
     ],
     "@typescript-eslint/no-array-constructor": Array [
       "error",
@@ -10220,6 +10240,16 @@ Object {
           "unused",
         ],
         "selector": "parameter",
+      },
+      Object {
+        "format": null,
+        "modifiers": Array [
+          "requiresQuotes",
+        ],
+        "selector": Array [
+          "objectLiteralProperty",
+          "typeProperty",
+        ],
       },
     ],
     "@typescript-eslint/no-array-constructor": Array [


### PR DESCRIPTION
Some of the APIs or query params we need to use require special
property keys, allow anything that requires quotes as object literals and
types.

eg:

```ts
queryParams: {
  'n:something': 'value',
}
```

or:

```ts
translate('something {here}', {
  '{here}': 'there',
})
```