### PR TITLE
fix(config): Allow functions returning promises to be passed into jsx attributes that expect void return

### DIFF
--- a/packages/eslint-config/configs/typescript.js
+++ b/packages/eslint-config/configs/typescript.js
@@ -88,6 +88,14 @@ module.exports = {
     ],
     '@typescript-eslint/no-duplicate-imports': 'error',
     '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/no-misused-promises': [
+      'error',
+      {
+        checksVoidReturn: {
+          attributes: false,
+        },
+      },
+    ],
     '@typescript-eslint/no-namespace': [
       'error',
       {

--- a/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/eslint.spec.js.snap
@@ -233,6 +233,11 @@ Object {
     ],
     "@typescript-eslint/no-misused-promises": Array [
       "error",
+      Object {
+        "checksVoidReturn": Object {
+          "attributes": false,
+        },
+      },
     ],
     "@typescript-eslint/no-namespace": Array [
       "error",
@@ -8081,6 +8086,11 @@ Object {
     ],
     "@typescript-eslint/no-misused-promises": Array [
       "error",
+      Object {
+        "checksVoidReturn": Object {
+          "attributes": false,
+        },
+      },
     ],
     "@typescript-eslint/no-namespace": Array [
       "error",
@@ -10301,6 +10311,11 @@ Object {
     ],
     "@typescript-eslint/no-misused-promises": Array [
       "error",
+      Object {
+        "checksVoidReturn": Object {
+          "attributes": false,
+        },
+      },
     ],
     "@typescript-eslint/no-namespace": Array [
       "error",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -18,7 +18,7 @@
     "tsutils": "^3.21.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^5.2.0",
+    "@typescript-eslint/parser": "^5.22.0",
     "eslint": "^8.0.0",
     "typescript": "^4.0.0"
   },


### PR DESCRIPTION
A recent change in the `no-misused-promises` rule made it fail when we
pass a function returning a promise into a prop that expects a void
return. This removes the check and relies on TS to make sure promises
are handled correctly.

```ts
const clicked = async () => {};

return <Component onClick={clicked} />
```

It won't allow promises in methods that are explicitly typed as void:

```diff
-const method = (): void => fetch();
+const method = (): void => {
+  void fetch();
+}
```