### PR TITLE
fix(config): FE-00 don't add jest rules if jest is not installed

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -3,7 +3,7 @@ const { hasPackage } = require('./utils');
 module.exports = {
   extends: ['./configs/base', './configs/jsdoc', './configs/prettier'],
   overrides: [
-    {
+    hasPackage('jest') && {
       extends: './configs/jest',
       files: ['**/*.spec.*', '**/spec.*', 'jest-setup.*'],
     },


### PR DESCRIPTION
## What & Why?
Don't add `jest` rules if `jest` is not present. This is currently failing for non-jest projects.

```
ESLint: 8.15.0

Error: Error while loading rule 'jest/no-deprecated-functions':
Unable to detect Jest version -
please ensure jest package is installed, or otherwise set version explicitly
```
