### PR TITLE
fix(config): FE-00 Mark `func-names` rule as error

### DIFF
--- a/packages/eslint-config/configs/base.js
+++ b/packages/eslint-config/configs/base.js
@@ -21,7 +21,7 @@ module.exports = {
     'default-param-last': 'error',
     'dot-notation': ['error', { allowKeywords: true }],
     eqeqeq: ['error', 'smart'],
-    'func-names': 'warn',
+    'func-names': 'error',
     'getter-return': ['error', { allowImplicit: true }],
     'gettext/no-variable-string': 'error',
     'global-require': 'error',

--- a/packages/eslint-config/test/__snapshots__/d.ts.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/d.ts.spec.js.snap
@@ -568,7 +568,7 @@ Object {
       "off",
     ],
     "func-names": Array [
-      "warn",
+      "error",
     ],
     "function-call-argument-newline": Array [
       "off",

--- a/packages/eslint-config/test/__snapshots__/js.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/js.spec.js.snap
@@ -224,7 +224,7 @@ Object {
       "off",
     ],
     "func-names": Array [
-      "warn",
+      "error",
     ],
     "function-call-argument-newline": Array [
       "off",

--- a/packages/eslint-config/test/__snapshots__/jsx.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/jsx.spec.js.snap
@@ -223,7 +223,7 @@ Object {
       "off",
     ],
     "func-names": Array [
-      "warn",
+      "error",
     ],
     "function-call-argument-newline": Array [
       "off",

--- a/packages/eslint-config/test/__snapshots__/spec.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/spec.spec.js.snap
@@ -228,7 +228,7 @@ Object {
       "off",
     ],
     "func-names": Array [
-      "warn",
+      "error",
     ],
     "function-call-argument-newline": Array [
       "off",

--- a/packages/eslint-config/test/__snapshots__/ts.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/ts.spec.js.snap
@@ -568,7 +568,7 @@ Object {
       "off",
     ],
     "func-names": Array [
-      "warn",
+      "error",
     ],
     "function-call-argument-newline": Array [
       "off",

--- a/packages/eslint-config/test/__snapshots__/tsx.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/tsx.spec.js.snap
@@ -568,7 +568,7 @@ Object {
       "off",
     ],
     "func-names": Array [
-      "warn",
+      "error",
     ],
     "function-call-argument-newline": Array [
       "off",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2144,9 +2144,9 @@ camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001271"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz"
-  integrity sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==
+  version "1.0.30001358"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz"
+  integrity sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
## What & Why?
We tend to mark as warnings things that'll get autofixed by eslint,
`func-names` doesn't have an autofix and must be fixed before saving.

## Examples
<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="523" alt="image" src="https://user-images.githubusercontent.com/4542735/174933687-bb21baf1-1f1a-48db-8528-2644153e1315.png">
	<td><img width="502" alt="image" src="https://user-images.githubusercontent.com/4542735/174933480-bc1a162b-7602-4818-935e-af338698051f.png">
</table>
