### PR TITLE
chore(common): FE-00 support typescript v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint": "^8.14.0",
     "jest": "^27.3.1",
     "lerna": "^4.0.0",
-    "typescript": "^4.6.4"
+    "typescript": "^5.0.2"
   },
   "dependencies": {}
 }

--- a/packages/eslint-config/configs/typescript.js
+++ b/packages/eslint-config/configs/typescript.js
@@ -21,6 +21,8 @@ module.exports = {
       },
     ],
     '@typescript-eslint/await-thenable': 'error',
+    '@typescript-eslint/block-spacing': 'off',
+    '@typescript-eslint/consistent-generic-constructors': 'off',
     '@typescript-eslint/consistent-type-assertions': [
       'error',
       {
@@ -43,6 +45,8 @@ module.exports = {
       },
     ],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/key-spacing': 'off',
+    '@typescript-eslint/lines-around-comment': 'off',
     '@typescript-eslint/member-ordering': 'error',
     '@typescript-eslint/naming-convention': [
       'error',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "@bigcommerce/eslint-plugin": "^1.1.1",
     "@rushstack/eslint-patch": "^1.1.3",
-    "@typescript-eslint/eslint-plugin": "^5.22.0",
-    "@typescript-eslint/parser": "^5.22.0",
+    "@typescript-eslint/eslint-plugin": "^5.56.0",
+    "@typescript-eslint/parser": "^5.56.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-plugin-gettext": "^1.2.0",
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "eslint": "^8.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/eslint-config/test/__snapshots__/d.ts.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/d.ts.spec.js.snap
@@ -59,6 +59,9 @@ Object {
     "@typescript-eslint/ban-types": Array [
       "error",
     ],
+    "@typescript-eslint/block-spacing": Array [
+      "off",
+    ],
     "@typescript-eslint/brace-style": Array [
       "off",
     ],
@@ -66,6 +69,9 @@ Object {
       "off",
     ],
     "@typescript-eslint/comma-spacing": Array [
+      "off",
+    ],
+    "@typescript-eslint/consistent-generic-constructors": Array [
       "off",
     ],
     "@typescript-eslint/consistent-type-assertions": Array [
@@ -108,7 +114,13 @@ Object {
     "@typescript-eslint/indent": Array [
       "off",
     ],
+    "@typescript-eslint/key-spacing": Array [
+      "off",
+    ],
     "@typescript-eslint/keyword-spacing": Array [
+      "off",
+    ],
+    "@typescript-eslint/lines-around-comment": Array [
       "off",
     ],
     "@typescript-eslint/member-delimiter-style": Array [

--- a/packages/eslint-config/test/__snapshots__/ts.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/ts.spec.js.snap
@@ -59,6 +59,9 @@ Object {
     "@typescript-eslint/ban-types": Array [
       "error",
     ],
+    "@typescript-eslint/block-spacing": Array [
+      "off",
+    ],
     "@typescript-eslint/brace-style": Array [
       "off",
     ],
@@ -66,6 +69,9 @@ Object {
       "off",
     ],
     "@typescript-eslint/comma-spacing": Array [
+      "off",
+    ],
+    "@typescript-eslint/consistent-generic-constructors": Array [
       "off",
     ],
     "@typescript-eslint/consistent-type-assertions": Array [
@@ -108,7 +114,13 @@ Object {
     "@typescript-eslint/indent": Array [
       "off",
     ],
+    "@typescript-eslint/key-spacing": Array [
+      "off",
+    ],
     "@typescript-eslint/keyword-spacing": Array [
+      "off",
+    ],
+    "@typescript-eslint/lines-around-comment": Array [
       "off",
     ],
     "@typescript-eslint/member-delimiter-style": Array [

--- a/packages/eslint-config/test/__snapshots__/tsx.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/tsx.spec.js.snap
@@ -59,6 +59,9 @@ Object {
     "@typescript-eslint/ban-types": Array [
       "error",
     ],
+    "@typescript-eslint/block-spacing": Array [
+      "off",
+    ],
     "@typescript-eslint/brace-style": Array [
       "off",
     ],
@@ -66,6 +69,9 @@ Object {
       "off",
     ],
     "@typescript-eslint/comma-spacing": Array [
+      "off",
+    ],
+    "@typescript-eslint/consistent-generic-constructors": Array [
       "off",
     ],
     "@typescript-eslint/consistent-type-assertions": Array [
@@ -108,7 +114,13 @@ Object {
     "@typescript-eslint/indent": Array [
       "off",
     ],
+    "@typescript-eslint/key-spacing": Array [
+      "off",
+    ],
     "@typescript-eslint/keyword-spacing": Array [
+      "off",
+    ],
+    "@typescript-eslint/lines-around-comment": Array [
       "off",
     ],
     "@typescript-eslint/member-delimiter-style": Array [

--- a/packages/eslint-config/test/__snapshots__/typescript-eslint.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/typescript-eslint.spec.js.snap
@@ -34,6 +34,9 @@ Object {
     "@typescript-eslint/ban-types": Array [
       "error",
     ],
+    "@typescript-eslint/block-spacing": Array [
+      "error",
+    ],
     "@typescript-eslint/brace-style": Array [
       "error",
     ],
@@ -44,6 +47,9 @@ Object {
       "error",
     ],
     "@typescript-eslint/comma-spacing": Array [
+      "error",
+    ],
+    "@typescript-eslint/consistent-generic-constructors": Array [
       "error",
     ],
     "@typescript-eslint/consistent-indexed-object-style": Array [
@@ -85,7 +91,13 @@ Object {
     "@typescript-eslint/init-declarations": Array [
       "error",
     ],
+    "@typescript-eslint/key-spacing": Array [
+      "error",
+    ],
     "@typescript-eslint/keyword-spacing": Array [
+      "error",
+    ],
+    "@typescript-eslint/lines-around-comment": Array [
       "error",
     ],
     "@typescript-eslint/lines-between-class-members": Array [
@@ -121,9 +133,6 @@ Object {
     "@typescript-eslint/no-duplicate-enum-values": Array [
       "error",
     ],
-    "@typescript-eslint/no-duplicate-imports": Array [
-      "error",
-    ],
     "@typescript-eslint/no-dynamic-delete": Array [
       "error",
     ],
@@ -157,6 +166,9 @@ Object {
     "@typescript-eslint/no-implied-eval": Array [
       "error",
     ],
+    "@typescript-eslint/no-import-type-side-effects": Array [
+      "error",
+    ],
     "@typescript-eslint/no-inferrable-types": Array [
       "error",
     ],
@@ -182,6 +194,9 @@ Object {
       "error",
     ],
     "@typescript-eslint/no-misused-promises": Array [
+      "error",
+    ],
+    "@typescript-eslint/no-mixed-enums": Array [
       "error",
     ],
     "@typescript-eslint/no-namespace": Array [
@@ -245,6 +260,9 @@ Object {
       "error",
     ],
     "@typescript-eslint/no-unsafe-call": Array [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-declaration-merging": Array [
       "error",
     ],
     "@typescript-eslint/no-unsafe-member-access": Array [
@@ -355,7 +373,7 @@ Object {
     "@typescript-eslint/semi": Array [
       "error",
     ],
-    "@typescript-eslint/sort-type-union-intersection-members": Array [
+    "@typescript-eslint/sort-type-constituents": Array [
       "error",
     ],
     "@typescript-eslint/space-before-blocks": Array [
@@ -388,6 +406,9 @@ Object {
     "@typescript-eslint/unified-signatures": Array [
       "error",
     ],
+    "block-spacing": Array [
+      "off",
+    ],
     "brace-style": Array [
       "off",
     ],
@@ -418,7 +439,13 @@ Object {
     "init-declarations": Array [
       "off",
     ],
+    "key-spacing": Array [
+      "off",
+    ],
     "keyword-spacing": Array [
+      "off",
+    ],
+    "lines-around-comment": Array [
       "off",
     ],
     "lines-between-class-members": Array [
@@ -437,9 +464,6 @@ Object {
       "off",
     ],
     "no-dupe-keys": Array [
-      "off",
-    ],
-    "no-duplicate-imports": Array [
       "off",
     ],
     "no-empty-function": Array [

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -14,16 +14,16 @@
     "directory": "packages/eslint-plugin"
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^5.22.0",
+    "@typescript-eslint/experimental-utils": "^5.56.0",
     "tsutils": "^3.21.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^5.22.0",
+    "@typescript-eslint/parser": "^5.56.0",
     "eslint": "^8.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
-    "@typescript-eslint/parser": "^5.22.0",
+    "@typescript-eslint/parser": "^5.56.0",
     "endent": "^2.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,6 +338,18 @@
     esquery "^1.4.0"
     jsdoc-type-pratt-parser "~3.0.1"
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz#a556790523a351b4e47e9d385f47265eaaf9780a"
+  integrity sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
+"@eslint-community/regexpp@^4.4.0":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.4.1.tgz#087cb8d9d757bb22e9c9946c9c0c2bf8806830f1"
+  integrity sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==
+
 "@eslint/eslintrc@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.2.tgz#4989b9e8c0216747ee7cca314ae73791bb281aae"
@@ -1543,6 +1555,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
   integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
 
+"@types/semver@^7.3.12":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
@@ -1560,37 +1577,38 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.22.0.tgz#7b52a0de2e664044f28b36419210aea4ab619e2a"
-  integrity sha512-YCiy5PUzpAeOPGQ7VSGDEY2NeYUV1B0swde2e0HzokRsHBYjSdF6DZ51OuRZxVPHx0032lXGLvOMls91D8FXlg==
+"@typescript-eslint/eslint-plugin@^5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz#e4fbb4d6dd8dab3e733485c1a44a02189ae75364"
+  integrity sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.22.0"
-    "@typescript-eslint/type-utils" "5.22.0"
-    "@typescript-eslint/utils" "5.22.0"
-    debug "^4.3.2"
-    functional-red-black-tree "^1.0.1"
-    ignore "^5.1.8"
-    regexpp "^3.2.0"
-    semver "^7.3.5"
+    "@eslint-community/regexpp" "^4.4.0"
+    "@typescript-eslint/scope-manager" "5.56.0"
+    "@typescript-eslint/type-utils" "5.56.0"
+    "@typescript-eslint/utils" "5.56.0"
+    debug "^4.3.4"
+    grapheme-splitter "^1.0.4"
+    ignore "^5.2.0"
+    natural-compare-lite "^1.4.0"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@^5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.22.0.tgz#a2b40eaa52ae1d1e316bc861069c40883a7ccf6e"
-  integrity sha512-rKxoCUtAHwEH6IcAoVpqipY6Th+YKW7WFspAKu0IFdbdKZpveFBeqxxE9Xn+GWikhq1o03V3VXbxIe+GdhggiQ==
+"@typescript-eslint/experimental-utils@^5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.56.0.tgz#2699b5eed7651cc361ac1e6ea2d31a0e51e989a5"
+  integrity sha512-sxWuj0eO5nItmKgZmsBbChVt90EhfkuncDCPbLAVeEJ+SCjXMcZN3AhhNbxed7IeGJ4XwsdL3/FMvD4r+FLqqA==
   dependencies:
-    "@typescript-eslint/utils" "5.22.0"
+    "@typescript-eslint/utils" "5.56.0"
 
-"@typescript-eslint/parser@^5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.22.0.tgz#7bedf8784ef0d5d60567c5ba4ce162460e70c178"
-  integrity sha512-piwC4krUpRDqPaPbFaycN70KCP87+PC5WZmrWs+DlVOxxmF+zI6b6hETv7Quy4s9wbkV16ikMeZgXsvzwI3icQ==
+"@typescript-eslint/parser@^5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.56.0.tgz#42eafb44b639ef1dbd54a3dbe628c446ca753ea6"
+  integrity sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.22.0"
-    "@typescript-eslint/types" "5.22.0"
-    "@typescript-eslint/typescript-estree" "5.22.0"
-    debug "^4.3.2"
+    "@typescript-eslint/scope-manager" "5.56.0"
+    "@typescript-eslint/types" "5.56.0"
+    "@typescript-eslint/typescript-estree" "5.56.0"
+    debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.22.0":
   version "5.22.0"
@@ -1600,19 +1618,33 @@
     "@typescript-eslint/types" "5.22.0"
     "@typescript-eslint/visitor-keys" "5.22.0"
 
-"@typescript-eslint/type-utils@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.22.0.tgz#0c0e93b34210e334fbe1bcb7250c470f4a537c19"
-  integrity sha512-iqfLZIsZhK2OEJ4cQ01xOq3NaCuG5FQRKyHicA3xhZxMgaxQazLUHbH/B2k9y5i7l3+o+B5ND9Mf1AWETeMISA==
+"@typescript-eslint/scope-manager@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz#62b4055088903b5254fa20403010e1c16d6ab725"
+  integrity sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==
   dependencies:
-    "@typescript-eslint/utils" "5.22.0"
-    debug "^4.3.2"
+    "@typescript-eslint/types" "5.56.0"
+    "@typescript-eslint/visitor-keys" "5.56.0"
+
+"@typescript-eslint/type-utils@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz#e6f004a072f09c42e263dc50e98c70b41a509685"
+  integrity sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.56.0"
+    "@typescript-eslint/utils" "5.56.0"
+    debug "^4.3.4"
     tsutils "^3.21.0"
 
 "@typescript-eslint/types@5.22.0":
   version "5.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.22.0.tgz#50a4266e457a5d4c4b87ac31903b28b06b2c3ed0"
   integrity sha512-T7owcXW4l0v7NTijmjGWwWf/1JqdlWiBzPqzAWhobxft0SiEvMJB56QXmeCQjrPuM8zEfGUKyPQr/L8+cFUBLw==
+
+"@typescript-eslint/types@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.56.0.tgz#b03f0bfd6fa2afff4e67c5795930aff398cbd834"
+  integrity sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==
 
 "@typescript-eslint/typescript-estree@5.22.0":
   version "5.22.0"
@@ -1627,7 +1659,34 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.22.0", "@typescript-eslint/utils@^5.10.0":
+"@typescript-eslint/typescript-estree@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz#48342aa2344649a03321e74cab9ccecb9af086c3"
+  integrity sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==
+  dependencies:
+    "@typescript-eslint/types" "5.56.0"
+    "@typescript-eslint/visitor-keys" "5.56.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.56.0.tgz#db64705409b9a15546053fb4deb2888b37df1f41"
+  integrity sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.56.0"
+    "@typescript-eslint/types" "5.56.0"
+    "@typescript-eslint/typescript-estree" "5.56.0"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
+
+"@typescript-eslint/utils@^5.10.0":
   version "5.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.22.0.tgz#1f2c4897e2cf7e44443c848a13c60407861babd8"
   integrity sha512-HodsGb037iobrWSUMS7QH6Hl1kppikjA1ELiJlNSTYf/UdMEwzgj0WIp+lBNb6WZ3zTwb0tEz51j0Wee3iJ3wQ==
@@ -1646,6 +1705,14 @@
   dependencies:
     "@typescript-eslint/types" "5.22.0"
     eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz#f19eb297d972417eb13cb69b35b3213e13cc214f"
+  integrity sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==
+  dependencies:
+    "@typescript-eslint/types" "5.56.0"
+    eslint-visitor-keys "^3.3.0"
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -3262,7 +3329,7 @@ fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
-fast-glob@^3.2.11:
+fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
@@ -3641,6 +3708,18 @@ globby@^11.0.4:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+globby@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^3.0.0"
+
 globby@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.2.tgz#29047105582427ab6eca4f905200667b056da515"
@@ -3661,6 +3740,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 handlebars@^4.7.6:
   version "4.7.7"
@@ -3819,7 +3903,7 @@ ignore-walk@^3.0.3:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^5.1.4, ignore@^5.1.8:
+ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -5304,6 +5388,11 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -7159,10 +7248,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.6.4:
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
-  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+typescript@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 uglify-js@^3.1.4:
   version "3.13.7"


### PR DESCRIPTION
## What & Why?
Support the latest TS@5 version. Includes a few new rules (see below comments).

## Examples
Ran inside `@bigcommerce/big-design` (only TS issues):

![Screenshot 2023-03-23 at 14 38 52](https://user-images.githubusercontent.com/10539418/227321894-5483a4be-c248-4829-b0ca-b3980c1e456d.png)

