### PR TITLE
feat: update ecmaVersion to latest

### DIFF
--- a/packages/eslint-config/configs/base.js
+++ b/packages/eslint-config/configs/base.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   extends: ['eslint:recommended', 'plugin:import/errors', 'plugin:import/warnings'],
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 'latest',
     sourceType: 'module',
   },
   plugins: ['import', 'gettext', 'switch-case'],

--- a/packages/eslint-config/test/__snapshots__/d.ts.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/d.ts.spec.js.snap
@@ -14,7 +14,7 @@ Object {
     "ecmaFeatures": Object {
       "jsx": true,
     },
-    "ecmaVersion": 2020,
+    "ecmaVersion": "latest",
     "project": "<rootDir>/tsconfig.json",
     "sourceType": "module",
   },

--- a/packages/eslint-config/test/__snapshots__/js.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/js.spec.js.snap
@@ -15,7 +15,7 @@ Object {
     "ecmaFeatures": Object {
       "jsx": true,
     },
-    "ecmaVersion": 2020,
+    "ecmaVersion": "latest",
     "sourceType": "module",
   },
   "plugins": Array [

--- a/packages/eslint-config/test/__snapshots__/jsx.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/jsx.spec.js.snap
@@ -14,7 +14,7 @@ Object {
     "ecmaFeatures": Object {
       "jsx": true,
     },
-    "ecmaVersion": 2020,
+    "ecmaVersion": "latest",
     "sourceType": "module",
   },
   "plugins": Array [

--- a/packages/eslint-config/test/__snapshots__/spec.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/spec.spec.js.snap
@@ -17,7 +17,7 @@ Object {
     "ecmaFeatures": Object {
       "jsx": true,
     },
-    "ecmaVersion": 2020,
+    "ecmaVersion": "latest",
     "sourceType": "module",
   },
   "plugins": Array [

--- a/packages/eslint-config/test/__snapshots__/ts.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/ts.spec.js.snap
@@ -14,7 +14,7 @@ Object {
     "ecmaFeatures": Object {
       "jsx": true,
     },
-    "ecmaVersion": 2020,
+    "ecmaVersion": "latest",
     "project": "<rootDir>/tsconfig.json",
     "sourceType": "module",
   },

--- a/packages/eslint-config/test/__snapshots__/tsx.spec.js.snap
+++ b/packages/eslint-config/test/__snapshots__/tsx.spec.js.snap
@@ -14,7 +14,7 @@ Object {
     "ecmaFeatures": Object {
       "jsx": true,
     },
-    "ecmaVersion": 2020,
+    "ecmaVersion": "latest",
     "project": "<rootDir>/tsconfig.json",
     "sourceType": "module",
   },


### PR DESCRIPTION
## What & Why?
Updates the `ecmaVersion` to `latest` in order to use the latest JS features. There are some modern features, like `import.meta` that can't be used with older `ecmaVersion` values. This enables features like that and more.

## Examples
Tested with Catalyst and works as expected:
![Screenshot 2024-04-08 at 14 16 18](https://github.com/bigcommerce/eslint-config/assets/10539418/98ad7e56-83dc-44ff-a941-f298710a4848)

