### PR TITLE
chore: Pin prettier/eslint-plugin-prettier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'tuesday'
+    ignore:
+      # Incompatible with Jest 29, remove when Jest 30 is available
+      - dependency-name: 'prettier'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'eslint-plugin-prettier'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
## What & Why?
Prettier 3.x is incompatible with Jest 29, this causes issues on any repo trying to use it and also having Jest 29 installed.

We can unpin it when Jest 30 is released.
