### PR TITLE
test: add check for deprecated rules

### DIFF
--- a/packages/eslint-config/test/d.ts.spec.js
+++ b/packages/eslint-config/test/d.ts.spec.js
@@ -15,3 +15,54 @@ it('checks that the rules are working', async () => {
 
   expect(result.messages).toEqual([]);
 });
+
+it('checks for rule deprecations', async () => {
+  const [result] = await getTSEslint().lintFiles([fileName]);
+
+  expect(result.usedDeprecatedRules).toMatchInlineSnapshot(`
+    [
+      {
+        "replacedBy": [],
+        "ruleId": "spaced-comment",
+      },
+      {
+        "replacedBy": [
+          "@stylistic/ts/padding-line-between-statements",
+        ],
+        "ruleId": "@typescript-eslint/padding-line-between-statements",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "global-require",
+      },
+      {
+        "replacedBy": [
+          "padding-line-between-statements",
+        ],
+        "ruleId": "lines-around-directive",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-buffer-constructor",
+      },
+      {
+        "replacedBy": [
+          "no-object-constructor",
+        ],
+        "ruleId": "no-new-object",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-new-require",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-path-concat",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-return-await",
+      },
+    ]
+  `);
+});

--- a/packages/eslint-config/test/js.spec.js
+++ b/packages/eslint-config/test/js.spec.js
@@ -15,3 +15,52 @@ it('checks that the rules are working', async () => {
 
   expect(result.messages).toEqual([]);
 });
+
+it('checks for rule deprecations', async () => {
+  const [result] = await getEslint().lintFiles([fileName]);
+
+  expect(result.usedDeprecatedRules).toMatchInlineSnapshot(`
+    [
+      {
+        "replacedBy": [],
+        "ruleId": "global-require",
+      },
+      {
+        "replacedBy": [
+          "padding-line-between-statements",
+        ],
+        "ruleId": "lines-around-directive",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-buffer-constructor",
+      },
+      {
+        "replacedBy": [
+          "no-object-constructor",
+        ],
+        "ruleId": "no-new-object",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-new-require",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-path-concat",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-return-await",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "padding-line-between-statements",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "spaced-comment",
+      },
+    ]
+  `);
+});

--- a/packages/eslint-config/test/jsx.spec.js
+++ b/packages/eslint-config/test/jsx.spec.js
@@ -15,3 +15,52 @@ it('checks that the rules are working', async () => {
 
   expect(result.messages).toEqual([]);
 });
+
+it('checks for rule deprecations', async () => {
+  const [result] = await getEslint().lintFiles([fileName]);
+
+  expect(result.usedDeprecatedRules).toMatchInlineSnapshot(`
+    [
+      {
+        "replacedBy": [],
+        "ruleId": "global-require",
+      },
+      {
+        "replacedBy": [
+          "padding-line-between-statements",
+        ],
+        "ruleId": "lines-around-directive",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-buffer-constructor",
+      },
+      {
+        "replacedBy": [
+          "no-object-constructor",
+        ],
+        "ruleId": "no-new-object",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-new-require",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-path-concat",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-return-await",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "padding-line-between-statements",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "spaced-comment",
+      },
+    ]
+  `);
+});

--- a/packages/eslint-config/test/spec.spec.js
+++ b/packages/eslint-config/test/spec.spec.js
@@ -15,3 +15,52 @@ it('checks that the rules are working', async () => {
 
   expect(result.messages).toEqual([]);
 });
+
+it('checks for rule deprecations', async () => {
+  const [result] = await getEslint().lintFiles([fileName]);
+
+  expect(result.usedDeprecatedRules).toMatchInlineSnapshot(`
+    [
+      {
+        "replacedBy": [],
+        "ruleId": "global-require",
+      },
+      {
+        "replacedBy": [
+          "padding-line-between-statements",
+        ],
+        "ruleId": "lines-around-directive",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-buffer-constructor",
+      },
+      {
+        "replacedBy": [
+          "no-object-constructor",
+        ],
+        "ruleId": "no-new-object",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-new-require",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-path-concat",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-return-await",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "padding-line-between-statements",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "spaced-comment",
+      },
+    ]
+  `);
+});

--- a/packages/eslint-config/test/ts.spec.js
+++ b/packages/eslint-config/test/ts.spec.js
@@ -15,3 +15,54 @@ it('checks that the rules are working', async () => {
 
   expect(result.messages).toEqual([]);
 });
+
+it('checks for rule deprecations', async () => {
+  const [result] = await getTSEslint().lintFiles([fileName]);
+
+  expect(result.usedDeprecatedRules).toMatchInlineSnapshot(`
+    [
+      {
+        "replacedBy": [
+          "@stylistic/ts/padding-line-between-statements",
+        ],
+        "ruleId": "@typescript-eslint/padding-line-between-statements",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "global-require",
+      },
+      {
+        "replacedBy": [
+          "padding-line-between-statements",
+        ],
+        "ruleId": "lines-around-directive",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-buffer-constructor",
+      },
+      {
+        "replacedBy": [
+          "no-object-constructor",
+        ],
+        "ruleId": "no-new-object",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-new-require",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-path-concat",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-return-await",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "spaced-comment",
+      },
+    ]
+  `);
+});

--- a/packages/eslint-config/test/tsx.spec.js
+++ b/packages/eslint-config/test/tsx.spec.js
@@ -15,3 +15,54 @@ it('checks that the rules are working', async () => {
 
   expect(result.messages).toEqual([]);
 });
+
+it('checks for rule deprecations', async () => {
+  const [result] = await getTSEslint().lintFiles([fileName]);
+
+  expect(result.usedDeprecatedRules).toMatchInlineSnapshot(`
+    [
+      {
+        "replacedBy": [
+          "@stylistic/ts/padding-line-between-statements",
+        ],
+        "ruleId": "@typescript-eslint/padding-line-between-statements",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "global-require",
+      },
+      {
+        "replacedBy": [
+          "padding-line-between-statements",
+        ],
+        "ruleId": "lines-around-directive",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-buffer-constructor",
+      },
+      {
+        "replacedBy": [
+          "no-object-constructor",
+        ],
+        "ruleId": "no-new-object",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-new-require",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-path-concat",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-return-await",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "spaced-comment",
+      },
+    ]
+  `);
+});


### PR DESCRIPTION
## What & Why?
Adds a test to check if there are any deprecated rules outstanding.

Will fix the deprecations in the next PR:
 - https://github.com/bigcommerce/eslint-config/pull/202

## Examples
n/a
