### PR TITLE
fix(plugin): update peer dependency

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -18,7 +18,7 @@
     "tsutils": "^3.21.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^5.56.0",
+    "@typescript-eslint/parser": "^7.8.0",
     "eslint": "^8.0.0",
     "typescript": "^4.0.0 || ^5.0.0"
   },


### PR DESCRIPTION
## What & Why?
The config relies on [version 7.8.0 of `@typescript-eslint/parser`](https://github.com/bigcommerce/eslint-config/blob/master/packages/eslint-config/package.json#L27), which means this peer dependency is out of sync with what the config wants. This updates the version to the same version as the config.
