### PR TITLE
QPT-796 Allow repos using eslint-config to upgrade eslint to 9 or above

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jest --projects packages/*"
   },
   "peerDependencies": {
-    "eslint": ">=8.14.0 <10"
+    "eslint": "^8.14.0 || ^9.0.0"
   },
   "devDependencies": {
     "eslint": "^8.14.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "release": "lerna publish --sign-git-commit --sign-git-tag --git-remote origin --pre-dist-tag next",
     "test": "jest --projects packages/*"
   },
+  "peerDependencies": {
+    "eslint": ">=8.14.0 <10"
+  },
   "devDependencies": {
     "eslint": "^8.14.0",
     "jest": "^29.7.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -47,7 +47,7 @@
     "react": "^18.3.1"
   },
   "peerDependencies": {
-    "eslint": "^8.0.0",
+    "eslint": "^8.0.0 || ^9.0.0",
     "typescript": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "@typescript-eslint/parser": "^8.0.0",
-    "eslint": "^8.0.0",
+    "eslint": "^8.0.0 || ^9.0.0",
     "typescript": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What & Why?
This PR adds eslint to peerDependencies with the version range >=8.14.0 <10, while still keeping it in devDependencies.
This enables consuming projects to upgrade to ESLint 9, without breaking this package’s local development or linting setup.

## Examples
N/A

ping @animesh1987 @icatalina 
