### PR TITLE
feat(config): add peer dependencies for hoisting

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -47,11 +47,19 @@
     "react": "^18.3.1"
   },
   "peerDependencies": {
+    "@typescript-eslint/parser": "^8.26.0",
     "eslint": "^8.0.0",
+    "eslint-import-resolver-typescript": "^3.8.3",
     "typescript": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {
+      "optional": true
+    },
+    "@typescript-eslint/parser": {
+      "optional": true
+    },
+    "eslint-import-resolver-typescript": {
       "optional": true
     }
   }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -47,9 +47,9 @@
     "react": "^18.3.1"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^8.26.0",
+    "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^8.0.0",
-    "eslint-import-resolver-typescript": "^3.8.3",
+    "eslint-import-resolver-typescript": "^3.0.0 || ^4.0.0",
     "typescript": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## What & Why?

Add `@typescript-eslint/parser` and `eslint-import-resolver-typescript` to peerDependencies while keeping them in dependencies. This ensures:

- They're always installed (via dependencies)
- They're hoisted to root node_modules (via peerDependencies)

Both are marked as optional in `peerDependenciesMeta` to avoid peer warnings in consuming projects.

### Changes to peerDependencies:
- `@typescript-eslint/parser`: `^8.0.0` (aligned with eslint-plugin requirement)
- `eslint-import-resolver-typescript`: `^3.0.0 || ^4.0.0` (supports current and future major versions)

### peerDependenciesMeta:
- `@typescript-eslint/parser`: optional
- `eslint-import-resolver-typescript`: optional

## Examples

N/A - This is a dependency configuration change, not a rule change.